### PR TITLE
feat(auth/mcp): auto-refresh OAuth tokens during SyncCredentials

### DIFF
--- a/packages/auth/mcp/paths.go
+++ b/packages/auth/mcp/paths.go
@@ -40,3 +40,9 @@ func providerKey(url string) string {
 func ProviderTokenPath(p Provider) string {
 	return filepath.Join(CacheDir(), "oauth", providerKey(p.URL), "tokens.json")
 }
+
+// ProviderClientPath returns the path to client.json (DCR-issued
+// client_id/secret) for p, whether or not it exists yet.
+func ProviderClientPath(p Provider) string {
+	return filepath.Join(CacheDir(), "oauth", providerKey(p.URL), "client.json")
+}

--- a/packages/auth/mcp/refresh.go
+++ b/packages/auth/mcp/refresh.go
@@ -1,0 +1,244 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+// DefaultRefreshLeeway is the window before token expiry within which
+// we proactively refresh. Picked to be larger than typical poll
+// intervals (per-spawn, per-talk) so we don't churn refreshes, but
+// small enough that we re-issue well before a hard expiry. For
+// Notion's 1h tokens this means refresh kicks in around the 55min
+// mark — still 5min of headroom for the request itself.
+const DefaultRefreshLeeway = 5 * time.Minute
+
+// httpClient is package-private so tests can swap it. Never call
+// http.DefaultClient directly from package code — that timeout-less
+// client can hang an entire spawn if a token endpoint stalls.
+var httpClient = &http.Client{Timeout: 15 * time.Second}
+
+// tokenFile mirrors the on-disk shape mcp2cli writes. Field names
+// match RFC 6749's token response so a refresh response decodes
+// directly into this struct.
+type tokenFile struct {
+	AccessToken  string `json:"access_token"`
+	TokenType    string `json:"token_type,omitempty"`
+	ExpiresIn    int    `json:"expires_in,omitempty"`
+	Scope        string `json:"scope,omitempty"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+}
+
+// clientFile mirrors mcp2cli's client.json. We only need the few
+// fields used during refresh (auth method, id/secret).
+type clientFile struct {
+	ClientID                string `json:"client_id"`
+	ClientSecret            string `json:"client_secret,omitempty"`
+	TokenEndpointAuthMethod string `json:"token_endpoint_auth_method,omitempty"`
+}
+
+// metadata is the subset of OAuth Authorization Server Metadata
+// (RFC 8414) we consume for refresh.
+type metadata struct {
+	TokenEndpoint string `json:"token_endpoint"`
+}
+
+// Refresh refreshes p's tokens via the refresh_token grant if the
+// stored access token is expired or will expire within `leeway`.
+// Returns whether a refresh actually happened.
+//
+// Silent on already-fresh tokens (returns false, nil). Silent on
+// missing tokens (returns false, nil) so callers can call this
+// unconditionally without first checking IsAuthenticated. Errors
+// are non-fatal for callers — log and continue.
+func Refresh(ctx context.Context, p Provider, leeway time.Duration) (bool, error) {
+	tokensPath := ProviderTokenPath(p)
+	fi, err := os.Stat(tokensPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("stat tokens: %w", err)
+	}
+
+	rawTokens, err := os.ReadFile(tokensPath)
+	if err != nil {
+		return false, fmt.Errorf("read tokens: %w", err)
+	}
+	var t tokenFile
+	if err := json.Unmarshal(rawTokens, &t); err != nil {
+		return false, fmt.Errorf("parse tokens: %w", err)
+	}
+
+	// No expires_in → assume non-expiring (some providers).
+	if t.ExpiresIn <= 0 {
+		return false, nil
+	}
+	expiry := fi.ModTime().Add(time.Duration(t.ExpiresIn) * time.Second)
+	if time.Until(expiry) > leeway {
+		return false, nil // still fresh
+	}
+
+	if t.RefreshToken == "" {
+		return false, fmt.Errorf("token expired and no refresh_token; re-run `spwn auth login %s`", p.Name)
+	}
+
+	rawClient, err := os.ReadFile(ProviderClientPath(p))
+	if err != nil {
+		return false, fmt.Errorf("read client info: %w", err)
+	}
+	var c clientFile
+	if err := json.Unmarshal(rawClient, &c); err != nil {
+		return false, fmt.Errorf("parse client info: %w", err)
+	}
+
+	tokenEndpoint, err := discoverTokenEndpoint(ctx, p.URL)
+	if err != nil {
+		return false, fmt.Errorf("discover token endpoint: %w", err)
+	}
+
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", t.RefreshToken)
+
+	req, err := http.NewRequestWithContext(ctx, "POST", tokenEndpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return false, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	// Auth: client_secret_basic (default per spec) when we have a secret.
+	// Public clients (PKCE without secret) put client_id in the form.
+	if c.ClientSecret != "" {
+		req.SetBasicAuth(c.ClientID, c.ClientSecret)
+	} else if c.ClientID != "" {
+		form.Set("client_id", c.ClientID)
+		req.Body = io.NopCloser(strings.NewReader(form.Encode()))
+		req.ContentLength = int64(len(form.Encode()))
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("token endpoint: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return false, fmt.Errorf("token endpoint returned %d: %s", resp.StatusCode, body)
+	}
+
+	var newT tokenFile
+	if err := json.Unmarshal(body, &newT); err != nil {
+		return false, fmt.Errorf("parse token response: %w", err)
+	}
+	if newT.AccessToken == "" {
+		return false, fmt.Errorf("token response had no access_token")
+	}
+
+	// Preserve refresh_token across rotation policies. Some providers
+	// rotate (return a new one); others don't. If absent in the
+	// response, we keep the existing refresh_token alive.
+	if newT.RefreshToken == "" {
+		newT.RefreshToken = t.RefreshToken
+	}
+
+	out, err := json.Marshal(newT)
+	if err != nil {
+		return false, err
+	}
+
+	// Atomic replace so a partial write never corrupts tokens.json.
+	tmp := tokensPath + ".tmp"
+	if err := os.WriteFile(tmp, out, 0o600); err != nil {
+		return false, err
+	}
+	if err := os.Rename(tmp, tokensPath); err != nil {
+		_ = os.Remove(tmp)
+		return false, err
+	}
+	return true, nil
+}
+
+// RefreshAll iterates the Registry and refreshes any provider whose
+// tokens are expired or expiring within leeway. Returns the count of
+// successful refreshes and per-provider errors. Per-provider failures
+// don't stop iteration — one broken provider shouldn't lock out the rest.
+//
+// Each provider gets a 30s deadline. Calling RefreshAll from a hot
+// path (every world spawn) is safe: it's a no-op when tokens are
+// fresh, and bounded when they aren't.
+func RefreshAll(ctx context.Context, leeway time.Duration) (refreshed int, errs []error) {
+	for _, p := range Registry {
+		pCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		ok, err := Refresh(pCtx, p, leeway)
+		cancel()
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", p.Name, err))
+			continue
+		}
+		if ok {
+			refreshed++
+		}
+	}
+	return refreshed, errs
+}
+
+// discoverTokenEndpoint fetches OAuth Authorization Server Metadata
+// (RFC 8414) for the given resource server URL. Tries the resource
+// URL's well-known first, then falls back to the origin
+// (scheme://host) — different providers host the document at
+// different levels.
+func discoverTokenEndpoint(ctx context.Context, resourceURL string) (string, error) {
+	candidates := []string{
+		strings.TrimRight(resourceURL, "/") + "/.well-known/oauth-authorization-server",
+	}
+	if u, err := url.Parse(resourceURL); err == nil && u.Scheme != "" && u.Host != "" {
+		origin := u.Scheme + "://" + u.Host + "/.well-known/oauth-authorization-server"
+		if origin != candidates[0] {
+			candidates = append(candidates, origin)
+		}
+	}
+
+	var lastErr error
+	for _, c := range candidates {
+		req, err := http.NewRequestWithContext(ctx, "GET", c, nil)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			lastErr = fmt.Errorf("%s: status %d", c, resp.StatusCode)
+			continue
+		}
+		var md metadata
+		if err := json.Unmarshal(body, &md); err != nil {
+			lastErr = fmt.Errorf("%s: %w", c, err)
+			continue
+		}
+		if md.TokenEndpoint == "" {
+			lastErr = fmt.Errorf("%s: empty token_endpoint", c)
+			continue
+		}
+		return md.TokenEndpoint, nil
+	}
+	if lastErr != nil {
+		return "", lastErr
+	}
+	return "", fmt.Errorf("no candidates produced metadata for %s", resourceURL)
+}

--- a/packages/auth/mcp/refresh_test.go
+++ b/packages/auth/mcp/refresh_test.go
@@ -1,0 +1,239 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// newTestProvider stands up a fake OAuth server (well-known + token
+// endpoint) and seeds the on-disk credential layout so Refresh has
+// something to work with. Returns the provider whose URL points at
+// the fake server. Cleans up on test exit.
+func newTestProvider(t *testing.T, tokens tokenFile, client clientFile, refreshHandler http.HandlerFunc) Provider {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(metadata{TokenEndpoint: "PLACEHOLDER"})
+	})
+	mux.HandleFunc("/token", refreshHandler)
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	// Patch metadata to point at the test server.
+	mux.HandleFunc("/.well-known/oauth-authorization-server-real", func(w http.ResponseWriter, r *http.Request) {})
+	// Re-register with correct token endpoint now that we know srv.URL.
+	mux2 := http.NewServeMux()
+	mux2.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"token_endpoint": srv.URL + "/token"})
+	})
+	mux2.HandleFunc("/token", refreshHandler)
+	srv.Config.Handler = mux2
+
+	p := Provider{Name: "test", URL: srv.URL + "/mcp"}
+
+	// Seed on-disk creds.
+	tmp := t.TempDir()
+	t.Setenv("SPWN_HOME", tmp)
+	dir := filepath.Dir(ProviderTokenPath(p))
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	tokensJSON, _ := json.Marshal(tokens)
+	if err := os.WriteFile(ProviderTokenPath(p), tokensJSON, 0o600); err != nil {
+		t.Fatalf("write tokens: %v", err)
+	}
+	clientJSON, _ := json.Marshal(client)
+	if err := os.WriteFile(ProviderClientPath(p), clientJSON, 0o600); err != nil {
+		t.Fatalf("write client: %v", err)
+	}
+
+	return p
+}
+
+func TestRefresh_NoTokens_NoOp(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("SPWN_HOME", tmp)
+	p := Provider{Name: "test", URL: "https://example.com/mcp"}
+
+	ok, err := Refresh(context.Background(), p, DefaultRefreshLeeway)
+	if err != nil {
+		t.Fatalf("expected no error for missing tokens, got %v", err)
+	}
+	if ok {
+		t.Errorf("expected ok=false for missing tokens, got true")
+	}
+}
+
+func TestRefresh_FreshTokens_NoOp(t *testing.T) {
+	tokens := tokenFile{
+		AccessToken:  "access-fresh",
+		TokenType:    "Bearer",
+		ExpiresIn:    3600,
+		RefreshToken: "refresh-1",
+	}
+	client := clientFile{ClientID: "cid", ClientSecret: "csecret"}
+
+	called := false
+	p := newTestProvider(t, tokens, client, func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})
+
+	ok, err := Refresh(context.Background(), p, DefaultRefreshLeeway)
+	if err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if ok {
+		t.Errorf("expected ok=false (token still fresh), got true")
+	}
+	if called {
+		t.Errorf("token endpoint should not have been called for a fresh token")
+	}
+}
+
+func TestRefresh_ExpiredTokens_RefreshesAndPreservesRefreshToken(t *testing.T) {
+	tokens := tokenFile{
+		AccessToken:  "access-old",
+		TokenType:    "Bearer",
+		ExpiresIn:    3600,
+		RefreshToken: "refresh-1",
+	}
+	client := clientFile{ClientID: "cid", ClientSecret: "csecret"}
+
+	var observedAuth string
+	p := newTestProvider(t, tokens, client, func(w http.ResponseWriter, r *http.Request) {
+		observedAuth = r.Header.Get("Authorization")
+		// Respond with a new access_token but no new refresh_token (so we
+		// exercise the "preserve refresh_token" branch).
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(tokenFile{
+			AccessToken: "access-new",
+			TokenType:   "Bearer",
+			ExpiresIn:   3600,
+		})
+	})
+
+	// Backdate mtime so the token reads as expired.
+	old := time.Now().Add(-2 * time.Hour)
+	_ = os.Chtimes(ProviderTokenPath(p), old, old)
+
+	ok, err := Refresh(context.Background(), p, DefaultRefreshLeeway)
+	if err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected ok=true (token refreshed)")
+	}
+	if observedAuth == "" {
+		t.Errorf("expected client_secret_basic Authorization header, got empty")
+	}
+
+	// Verify on-disk state.
+	raw, _ := os.ReadFile(ProviderTokenPath(p))
+	var got tokenFile
+	_ = json.Unmarshal(raw, &got)
+	if got.AccessToken != "access-new" {
+		t.Errorf("AccessToken = %q; want %q", got.AccessToken, "access-new")
+	}
+	if got.RefreshToken != "refresh-1" {
+		t.Errorf("RefreshToken not preserved: got %q; want %q", got.RefreshToken, "refresh-1")
+	}
+}
+
+func TestRefresh_ExpiredButNoRefreshToken_ErrorsActionably(t *testing.T) {
+	tokens := tokenFile{
+		AccessToken: "access-old",
+		TokenType:   "Bearer",
+		ExpiresIn:   3600,
+		// no RefreshToken
+	}
+	client := clientFile{ClientID: "cid", ClientSecret: "csecret"}
+
+	p := newTestProvider(t, tokens, client, func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("token endpoint should not be called when refresh_token is absent")
+	})
+
+	old := time.Now().Add(-2 * time.Hour)
+	_ = os.Chtimes(ProviderTokenPath(p), old, old)
+
+	_, err := Refresh(context.Background(), p, DefaultRefreshLeeway)
+	if err == nil {
+		t.Fatal("expected error pointing user to spwn auth login")
+	}
+}
+
+func TestRefresh_TokenEndpointReturns400_ReturnsErrorAndKeepsOldFile(t *testing.T) {
+	tokens := tokenFile{
+		AccessToken:  "access-old",
+		TokenType:    "Bearer",
+		ExpiresIn:    3600,
+		RefreshToken: "refresh-1",
+	}
+	client := clientFile{ClientID: "cid", ClientSecret: "csecret"}
+
+	p := newTestProvider(t, tokens, client, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
+	})
+
+	old := time.Now().Add(-2 * time.Hour)
+	_ = os.Chtimes(ProviderTokenPath(p), old, old)
+
+	_, err := Refresh(context.Background(), p, DefaultRefreshLeeway)
+	if err == nil {
+		t.Fatal("expected error from 400 response")
+	}
+
+	// Old tokens.json must still be there.
+	raw, _ := os.ReadFile(ProviderTokenPath(p))
+	var got tokenFile
+	_ = json.Unmarshal(raw, &got)
+	if got.AccessToken != "access-old" {
+		t.Errorf("AccessToken should remain unchanged on refresh failure; got %q", got.AccessToken)
+	}
+}
+
+func TestRefresh_PublicClient_PutsClientIDInForm(t *testing.T) {
+	tokens := tokenFile{
+		AccessToken:  "access-old",
+		TokenType:    "Bearer",
+		ExpiresIn:    3600,
+		RefreshToken: "refresh-1",
+	}
+	// Public client (PKCE without secret).
+	client := clientFile{ClientID: "public-cid", TokenEndpointAuthMethod: "none"}
+
+	var sawAuthHeader, sawClientIDInBody bool
+	p := newTestProvider(t, tokens, client, func(w http.ResponseWriter, r *http.Request) {
+		sawAuthHeader = r.Header.Get("Authorization") != ""
+		_ = r.ParseForm()
+		sawClientIDInBody = r.PostForm.Get("client_id") != ""
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(tokenFile{
+			AccessToken: "access-new", TokenType: "Bearer", ExpiresIn: 3600,
+		})
+	})
+
+	old := time.Now().Add(-2 * time.Hour)
+	_ = os.Chtimes(ProviderTokenPath(p), old, old)
+
+	if _, err := Refresh(context.Background(), p, DefaultRefreshLeeway); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if sawAuthHeader {
+		t.Errorf("public client must not send Basic auth header")
+	}
+	if !sawClientIDInBody {
+		t.Errorf("public client must include client_id in form body")
+	}
+}

--- a/packages/auth/mcp/status.go
+++ b/packages/auth/mcp/status.go
@@ -3,9 +3,10 @@ package mcp
 import "os"
 
 // IsAuthenticated reports whether a tokens.json exists for p. The
-// presence of the file is the spwn-side signal — mcp2cli refreshes
-// it transparently on each call, so any stale-token concerns live
-// inside mcp2cli, not here.
+// presence of the file is the spwn-side signal: an actual access
+// token's freshness is the responsibility of Refresh (called from
+// auth.SyncCredentials on every world spawn), so callers don't need
+// to think about expiry here.
 func IsAuthenticated(p Provider) bool {
 	_, err := os.Stat(ProviderTokenPath(p))
 	return err == nil

--- a/packages/auth/sync.go
+++ b/packages/auth/sync.go
@@ -1,14 +1,17 @@
 package auth
 
 import (
+	"context"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 	"time"
 
+	"spwn.sh/packages/auth/mcp"
 	"spwn.sh/packages/platform"
 )
 
@@ -42,6 +45,18 @@ func SyncCredentials() error {
 	// Sync runtime-specific files (e.g., codex auth.json)
 	if err := syncRuntimeFiles(dir); err != nil {
 		return fmt.Errorf("sync runtime files: %w", err)
+	}
+
+	// Refresh expiring MCP OAuth tokens (Notion etc) so containers
+	// spawned with the cred bind mount get fresh tokens. Per-provider
+	// failures are logged but never block sync — a broken refresh
+	// shouldn't take down `spwn up` or `spwn agent talk`.
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	if _, errs := mcp.RefreshAll(ctx, mcp.DefaultRefreshLeeway); len(errs) > 0 {
+		for _, err := range errs {
+			log.Printf("warning: mcp token refresh: %v", err)
+		}
 	}
 
 	// Write sync timestamp


### PR DESCRIPTION
## Summary

- MCP OAuth tokens (Notion's are 1h TTL) currently aren't refreshed by spwn — when they expire, mcp2cli inside the world tries a fresh OAuth dance, opens a browser URL the agent can't follow, and hangs.
- Add ` mcp.Refresh` / `mcp.RefreshAll` that exchange the cached `refresh_token` against the provider's token endpoint (discovered via RFC 8414) and atomically replace `tokens.json`.
- Wire `RefreshAll` into `auth.SyncCredentials` with a 5-min leeway so `spwn up`, `spwn agent talk`, and login events keep every provider's tokens fresh without any user action. Per-provider failures log a warning but never block sync.

## Why now

Provoked by `tool:notion` work in a downstream project: the wrapper called `notion-mcp` from inside an agent, mcp2cli saw an expired token, opened `https://mcp.notion.com/authorize?...` and hung. The `IsAuthenticated` comment in `status.go` claimed mcp2cli would refresh transparently — it doesn't (or the refresh path doesn't reach Notion correctly via mcp2cli's PKCE flow). Either way, spwn already owns the tokens on disk and the refresh grant is a one-line POST; doing it host-side is invisible and reliable.

## Test plan

- [x] `go test ./packages/auth/mcp/... -v -run TestRefresh` — 6 new tests cover: missing tokens (no-op), fresh tokens (no-op, no HTTP call), expired tokens (refresh + preserve `refresh_token` for non-rotating providers), no-refresh-token (actionable error), 400 from token endpoint (error + leaves old file intact), public PKCE clients (`client_id` in form body, no Basic auth).
- [x] `go test ./packages/auth/...` — full auth package green.
- [x] End-to-end against real Notion: backdate `tokens.json` mtime to simulate expiry, run `spwn up brain` → `SyncCredentials` triggers `RefreshAll` → token file rewritten → `notion-mcp notion-search` returns real workspace data. Zero user-visible output.

## Notes

- `IsAuthenticated` comment updated to reflect the new reality (refresh lives in `Refresh`, not in mcp2cli).
- `ProviderClientPath` added next to `ProviderTokenPath` in `paths.go` so callers don't reach into internal layout.
- New `httpClient` (15s timeout) used for both metadata discovery and the token grant — never `http.DefaultClient`, which has no timeout and could hang a spawn.
- `DefaultRefreshLeeway = 5 * time.Minute` — large enough that frequent SyncCredentials calls don't churn refreshes (one per ~55min for a 1h token), small enough that the new token is in hand well before expiry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)