### PR TITLE
docs: the knowledge only this repo can falsify moves in

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,11 @@ Knowledge is world-scoped, not held in the Mind. A spwn project lives **in the r
 | Monorepo layout, layered dependency graph, DooD, code style | [`docs/05-architecture.md`](docs/05-architecture.md) |
 | Host-side gate: cookies, MCP routing, browser sidecar | [`docs/06-gate.md`](docs/06-gate.md) |
 | Testing strategy, layer pyramid, running the suites | [`docs/07-testing.md`](docs/07-testing.md) |
+| How a world runs, the Backend port, mounts and what persists | [`docs/08-worlds.md`](docs/08-worlds.md) |
+| Constants, laws, elements, the world context an agent reads | [`docs/09-physics.md`](docs/09-physics.md) |
+| Identity, skills, memory; Dream, Sleep, versioning a Mind | [`docs/10-mind.md`](docs/10-mind.md) |
+| The web UI and the API behind it | [`docs/11-observatory.md`](docs/11-observatory.md) |
+| Why a choice was made | [`docs/decisions/`](docs/decisions/README.md) |
 | Automations (cron + fs triggers) | [`docs/automations.md`](docs/automations.md) |
 | Worked examples | [`docs/recipes.md`](docs/recipes.md) |
 | Built-in `spwn:*` catalog | [`docs/dependency-catalog.md`](docs/dependency-catalog.md) |

--- a/docs/02-concepts.md
+++ b/docs/02-concepts.md
@@ -62,3 +62,4 @@ spwn is built spec-first — the test suite is the living specification. See [Te
 - [Getting started](01-getting-started.md) — install and first agent.
 - [Primitives](04-primitives.md) — the on-disk shape of each block.
 - [Architecture](05-architecture.md) — how the packages that own these abstractions are layered.
+- [Worlds](08-worlds.md) · [Physics](09-physics.md) · [The Mind](10-mind.md) — the design behind the three abstractions.

--- a/docs/02-concepts.md
+++ b/docs/02-concepts.md
@@ -40,6 +40,8 @@ Knowledge is **world-scoped**, not held in the Mind: declare a host path via `wo
 - **Worker** — persistent worker agent with its own identity and memory.
 - **NPC** — ephemeral agent, no persistent memory. Single task, fire-and-forget.
 
+Each agent declares one of these as its `role:` — `chief`, `manager`, `worker`, or `npc` ([Primitives](04-primitives.md)). Product and marketing material uses a parallel vocabulary for the same tiers: a Governor is a chief, a Citizen is a worker, an NPC is an npc. The role names above are the ones the manifests and the CLI accept.
+
 ### Evolution
 
 - **Dream** — analyze experience, discover patterns, promote successes to playbooks. `spwn agent dream <name>`

--- a/docs/03-cli.md
+++ b/docs/03-cli.md
@@ -11,6 +11,10 @@ Design rules:
 - Strict noun-first grammar. The only top-level verbs are the shortcuts `up`, `ls`, `talk`.
 - `rm` is contextual: `spwn agent rm neo` deletes the agent; `spwn agent rm neo --dependency X` removes a dep from it.
 - Inside a project, commands resolve against `./spwn/` first. Outside a project, they operate on user-level paths.
+- Names for creation, IDs for reference: creation takes a name, and a running instance is addressed by the ID it was given ([Concepts](02-concepts.md#ids)).
+- `--json` wherever output is worth consuming programmatically.
+
+Two invariants hold across the surface. Commands speak the domain's vocabulary — worlds, agents, souls, dreams — never the backend's. And the manifest is the input while the running world is the output: no command mutates a world image in place, so changing reality means changing `spwn.yaml` or a block file and rebuilding.
 
 ## Command map
 

--- a/docs/04-primitives.md
+++ b/docs/04-primitives.md
@@ -134,6 +134,14 @@ Refactor the code I've selected without changing observable behaviour…
 
 The body is written verbatim to `.claude/commands/<name>.md` or `.codex/commands/<name>.md`; frontmatter is interpreted by the runtime, not spwn. Use commands for short prompt shortcuts (5–20 lines); use skills for multi-phase capabilities with state and tool plumbing.
 
+## Invariants
+
+- **Input, not output.** The manifests declare what reality should be; what the agent reads at startup — physics, faculties, roster — is what it is after the build ([Physics](09-physics.md)). Operators author YAML, agents read rendered markdown.
+- **Declarative all the way down.** No manifest triggers behaviour by being edited; reality changes only through `spwn build` and `spwn up`.
+- **Composition, not restriction.** Security comes from what the world image lacks, never from a rule in YAML.
+- **Blocks are files.** Every skill, tool, hook, and command is one file or directory on disk, diffable and reviewable like code.
+- **Declared, then proven.** A tool's `verify:` probes run at the end of the image build, so a world that is missing what it promised fails the build instead of failing an agent.
+
 ## Related
 
 - [Getting started](01-getting-started.md) — the config hierarchy in context.

--- a/docs/05-architecture.md
+++ b/docs/05-architecture.md
@@ -73,7 +73,7 @@ compile.Tree           →  world.Spawn        →  running container + synced a
 
 ## Container architecture: Docker-outside-of-Docker (DooD)
 
-spwn uses **DooD**, not DinD. The host's Docker daemon is shared via socket mount (`/var/run/docker.sock`); every container is a **sibling** on the same daemon — no nesting, no privilege escalation, no performance overhead.
+spwn uses **DooD**, not DinD ([ADR-013](decisions/013-dood-over-dind.md)). The host's Docker daemon is shared via socket mount (`/var/run/docker.sock`); every container is a **sibling** on the same daemon — no nesting, no privilege escalation, no performance overhead.
 
 ```
 Host machine
@@ -99,6 +99,24 @@ The [gate](06-gate.md) is a separate long-running host container that owns cooki
 - **Labels are truth.** World state comes from Docker labels, not on-disk state.
 - **Compile is deterministic.** Same input → same output, covered by golden tests.
 - **Layers flow downward.** Enforced by depguard; no upward imports.
+- **External systems sit behind ports.** Every dependency on the outside world is a Go interface defined in the domain that uses it, with the adapter injected at startup — no domain package names a concrete backend ([ADR-011](decisions/011-ports-and-adapters.md)).
+
+## What the architecture does not do
+
+The boundaries are as load-bearing as the layers:
+
+- **It does not implement agent reasoning.** The runtime does the thinking, planning, and tool use; spwn creates the reality it operates in.
+- **It does not run inference.** No model call happens in the machinery — the runtime manages its own.
+- **It does not schedule work.** Worlds are created on demand, by an operator or by a declared trigger ([Automations](automations.md)).
+- **It does not network worlds together.** Each world is isolated; anything between two worlds goes through the host.
+- **It does not persist worlds.** The Soul and the Mind persist; worlds are disposable.
+- **It does not restrict behaviour through rules.** What an agent cannot do, it cannot do because the capability is absent from the image ([Physics](09-physics.md)).
+
+## Planned surfaces
+
+Thin SDKs are designed, not shipped: language wrappers (TypeScript first, then Python) over the same domain APIs the CLI consumes, so code can act as an operator — spawn a world, assign a task, collect the result — without shelling out. Today the shipped operator surfaces are the CLI and the web UI.
+
+The runtime stack has further designed-but-unshipped layers, each with its own record: a runtime normalization layer inside worlds ([ADR-008](decisions/008-rivet-runtime-layer.md)), multi-provider and subscription auth behind it ([ADR-010](decisions/010-pi-mono-multi-provider.md)), and the Architect's messaging channels ([ADR-009](decisions/009-zeroclaw-as-claw.md), [ADR-012](decisions/012-organization-manifest.md)).
 
 ## Code style
 
@@ -112,4 +130,5 @@ The [gate](06-gate.md) is a separate long-running host container that owns cooki
 - [Concepts](02-concepts.md) — the abstractions these packages implement.
 - [Gate](06-gate.md) — the host-side broker container.
 - [Testing](07-testing.md) — how the layers are covered.
+- [Decisions](decisions/README.md) — why the stack, the layering, and the container model are what they are.
 - [`../CONTRIBUTING.md`](../CONTRIBUTING.md) · [`contributing/releasing.md`](contributing/releasing.md) · [`contributing/update-system.md`](contributing/update-system.md) — contributor runbooks.

--- a/docs/06-gate.md
+++ b/docs/06-gate.md
@@ -2,7 +2,11 @@
 
 > 🚧 **Experimental.** The gate container, the `gate:` block, the Node SDK, and the cookie-sync extension are in active development — schema, CLI, and behaviour will change without notice. Don't depend on it in production.
 
-The **gate** is a long-running Docker container on the host (`spwn gate start`). It owns three concerns no individual world should:
+The gate is the one sanctioned crossing between the host and a world. Everything else about a world is closed by construction; the gate is where declared, scoped capability enters — a host service surfaced inside the world as an ordinary command, so the agent sees an element that exists and never an endpoint ([Physics](09-physics.md)).
+
+Four concerns sit behind that: **capability bridging** (external services as plain CLI commands), **credential custody** (secrets and cookies stay host-side, never in a world's image or filesystem), **session relay** (operator traffic in, agent output back), and **supervision** (the bridged capability is spawned, health-checked, and respawned by the gate, not by the agent).
+
+The shipped implementation is a long-running Docker container on the host (`spwn gate start`). It owns three concerns no individual world should:
 
 1. **Cookie sync** — receives session cookies from the `spwn-cookie-sync` Chrome extension at `/sync/<provider>` and persists them under `~/.spwn/credentials/<provider>/cookies.json`.
 2. **MCP routing** — exposes `/mcp/<element>/*` for every registered element (Notion proxy, Gmail/Gcal via `gws`, every catalog tool loaded from `~/.spwn/gate/tools/`).
@@ -70,7 +74,23 @@ dependencies:
 
 The compile pipeline materializes this as `/etc/spwn/policy/<short>.json` in the agent's image. The catalog tool's wrapper consults it via `spwn-policy-check <tool> <method>` (installed by `spwn:mcp2cli`) and rejects denied calls before they hit the gate. Merging is deny-takes-precedence when multiple agents in one world hold conflicting policies.
 
+## Invariants
+
+These hold whatever the implementation looks like:
+
+1. **One crossing.** The gate connection is the only thing that crosses the container boundary; the Docker socket is never passed into a world.
+2. **Bridges are declared, then verified.** A capability reaches a world only through its manifests, and only what was declared appears in the agent's faculties.
+3. **Credentials never enter the world.** The wrapper carries the request; the gate holds the cookie or key and makes the authenticated call host-side.
+4. **Scoping is per capability, not per service.** A bridge exposes named methods, and per-agent allow/deny keeps write-capable or human-in-the-loop methods out of agent reach by construction.
+5. **Runtime-agnostic.** The bridge surfaces as ordinary commands, so any runtime that can run a shell can use it; swapping runtimes never touches the gate.
+
+## Open question: communication between worlds
+
+Undecided — whether two worlds should be able to reach each other. No direct communication (where things stand today) keeps isolation strong but rules out collaborative patterns; a host relay through the gate keeps isolation clean at the cost of latency and a host bottleneck; direct networking breaks the isolation model outright. Leaning toward the host relay.
+
 ## Related
 
 - [Primitives](04-primitives.md) — the `gate:` block on a `tool.yaml`.
+- [Physics](09-physics.md) — why a bridged capability is modelled as an element.
 - [Architecture](05-architecture.md) — where the gate sits relative to worlds.
+- [ADR-001](decisions/001-gate-over-socket.md) · [ADR-006](decisions/006-acp-inside-container.md) · [ADR-007](decisions/007-rust-container-gate.md) — the transport abstraction and the two-sided design that preceded the shipped host broker.

--- a/docs/08-worlds.md
+++ b/docs/08-worlds.md
@@ -1,0 +1,43 @@
+# Worlds
+
+A world is a Docker container started from the project image, and everything an agent keeps has to cross its boundary through a declared mount. This chapter is how a world runs, the port that runs it, and what moves in and out of it. The YAML that declares any of it is [Primitives](04-primitives.md).
+
+## How a world runs
+
+- **One image per project.** `spwn build` compiles the declared reality — agents, tools, skills, rendered context — into a project-specific image. Worlds are containers started from that image; nothing is installed at world-start time.
+- **Container labels are the world state.** The running backend is queried directly; there is no shadow registry to drift.
+- **Lifecycle**: create → start → run agents → stop or destroy. Destroying a world removes the container; everything worth keeping lives in a mount or in the agent's Mind.
+- **Session continuity survives the container.** An agent's session state persists with its Mind on the host, so re-entering a world — or being respawned after a crash — resumes the conversation instead of starting from zero.
+
+## The Backend port
+
+The machinery programs against an interface — provision, exec, mount, destroy, ensure-image — never against Docker itself ([`packages/container`](../packages/container) is the adapter, and [ADR-011](decisions/011-ports-and-adapters.md) the rule). Nothing above the port names Docker, which keeps the door open for stronger isolation backends without changing agent-facing behaviour.
+
+Docker is the default and, today, the only adapter. Designed, not shipped: edge deployment — ephemeral agents on lightweight infrastructure — as a second adapter behind the same port.
+
+## What crosses the boundary
+
+| Mechanism        | Direction       | Use case                                  | Persistence            |
+| ---------------- | --------------- | ----------------------------------------- | ---------------------- |
+| Workspace mount  | Bidirectional   | Task input and output (code, data, files) | Persists on the host   |
+| Knowledge mount  | Read into world | World-scoped reference material           | Persists on the host   |
+| Mind persistence | Bidirectional   | Agent memory (playbooks, journal)         | Persists across worlds |
+| Baked blocks     | Into the image  | Tools, skills, rendered context           | Rebuilt with the image |
+
+- **Workspaces** are host paths a world declares, mounted at `/workspace` — the way an agent is handed a project and its output collected. When the world is destroyed, the results stay on the host.
+- **Knowledge** is world-scoped, not agent-scoped: the path a world names is mounted at `/world/knowledge/`. Omit the key and no mount happens — the agents are never told a knowledge base exists.
+- **The Mind** — `SOUL.md`, playbooks, journal — lives on the host filesystem and travels with the agent across worlds; the journal is appended as sessions run ([The Mind](10-mind.md)).
+- **Everything composed** — tools, skills, the rendered operating manual — is baked into the image at build time and delivered to the paths each runtime expects. No bind-mount indirection and no symlinks, so a world's capabilities are immutable while it runs.
+
+## Invariants
+
+- **Mounts are explicit.** Only declared directories cross the boundary, so what an agent can touch on the host is enumerable from the manifests.
+- **Worlds are disposable; their mounts are not.** Everything an agent should keep lands in a mount; everything else dies with the world.
+- **Changes through a mount are immediately visible on the host** — these are bind mounts, not copies. Sharing one Mind between two live worlds is therefore possible and demands care; fork the agent instead.
+- **Secrets are not files in a world.** Credentialed capabilities reach agents through the [gate](06-gate.md), which keeps credentials host-side.
+
+## Related
+
+- [Physics](09-physics.md) — what exists inside the world once it is running.
+- [Architecture](05-architecture.md) — where the container adapter sits in the layer graph.
+- [Primitives](04-primitives.md) — `workspaces:`, `knowledge:`, and the blocks that get baked in.

--- a/docs/09-physics.md
+++ b/docs/09-physics.md
@@ -1,0 +1,55 @@
+# Physics
+
+Every world has its own physics: the constants, laws, and elements that decide what is possible inside it. This chapter is what those three mean, what the agent reads at startup, and why capability is modelled as physics rather than as configuration. How they are declared is [Primitives](04-primitives.md).
+
+## The three pillars
+
+- **Constants** are finite resource limits — CPU, memory, disk, timeout. They are fixed for the world's lifetime.
+- **Laws** are rules the environment enforces — network policy, process limits, filesystem mounts. They cannot be circumvented from inside, only declared differently in the next world.
+- **Elements** are the building blocks that exist — the tools and capabilities the composition declares. If an element is not declared, nothing in the world can be made from it.
+
+## Input and output
+
+The manifests are prescriptive: what reality should be. What the agent reads is descriptive: what reality is after the build.
+
+- **physics** — the constants, laws, and topology of its world.
+- **faculties** — the verified elements and bridges: what it can actually do.
+
+Both are rendered as plain markdown into the world context at build time, so any runtime that reads files understands its reality without a custom parser or an injected system prompt. Declared elements are verified during the image build — each tool's `verify:` probes run before any agent wakes up — and only what is proven present reaches the faculties.
+
+## The operating manual
+
+Every agent wakes up with an entry file assembled at build time from the world's shared context (physics, faculties, roster) plus its own identity and role. The build renders it to the convention of each runtime — `CLAUDE.md` for Claude Code, `AGENTS.md` for codex-style runtimes — so the runtime boots fully loaded with nothing to chase at startup.
+
+Platform instructions travel the same way. Rather than teaching every runtime adapter how spwn works, the build ships standardised markdown into every world; any runtime that reads files bootstraps itself from it. Two kinds of skill coexist, and the split is the point:
+
+|          | System skills            | Agent skills                 |
+| -------- | ------------------------ | ---------------------------- |
+| Source   | The platform             | The agent's composition      |
+| Optional | No, always present       | Yes, per agent via `skill/…` |
+| Mutable  | No, read-only in a world | Yes, authored and evolved    |
+| Purpose  | Platform operations      | Domain capabilities          |
+
+## Elements bridged from the host
+
+Some elements are not binaries in the image but host capabilities surfaced inside the world as ordinary commands by the [gate](06-gate.md). From the agent's side there is no difference: a bridged capability is an element that exists, listed in its faculties. A capability that is not bridged appears nowhere — not forbidden, absent.
+
+## Why elements are physics, not configuration
+
+The usual approach hands the agent a tool client and a list of servers. The agent then knows it is calling external services and can be talked into calling unauthorised ones. Modelling capability as physics removes the target:
+
+- **The bridge is invisible.** The agent sees a command, not an endpoint.
+- **Undeclared elements do not exist.** There is nothing to call, manipulate, or jailbreak.
+- **The faculties are the single source of truth.** What the agent reads is exactly what is available — no hidden capability, no surprise restriction.
+
+The layers stack: a bridged capability needs both the law-level gate connection and the element-level command, so even a binary that existed would have no host service to reach.
+
+## Open question: timeout behaviour
+
+Undecided — what happens when a world hits its timeout constant: hard kill (SIGKILL, no cleanup), graceful shutdown (SIGTERM, wait, SIGKILL, destroy), extend-and-warn (notify the agent, extend once, then shut down gracefully), or pause (freeze the world and wait for the operator). Leaning toward graceful shutdown with a configurable grace period.
+
+## Related
+
+- [Worlds](08-worlds.md) — the container the physics apply to.
+- [Primitives](04-primitives.md) — the manifests that declare constants, laws, and elements.
+- [Gate](06-gate.md) — how a host capability becomes an element.

--- a/docs/10-mind.md
+++ b/docs/10-mind.md
@@ -1,0 +1,120 @@
+# The Mind
+
+An agent is three layers — identity, skills, memory — and the whole point of drawing the line between them is how they behave over time. This chapter is that design: what each layer holds, what Sleep and Fork do to it, and how an agent's memory is versioned. The on-disk shape of the files is [Primitives](04-primitives.md); the vocabulary is [Concepts](02-concepts.md).
+
+## The three layers
+
+- **Identity** — the immutable core: purpose, values, bonds, role, voice. It does not fork, does not sleep, does not prune.
+- **Skills** — invocable capabilities: what the agent can do.
+- **Memory** — the evolving layer: knowledge, playbooks, journal. It grows through experience, restructures during Sleep, and branches when the agent is forked.
+
+The profile is mounted into every world the agent enters; without one, every world starts from zero. Identity is what keeps the accumulation coherent — an agent that evolves long enough without one drifts out of its purpose.
+
+Security constraints never live in any of these layers. They belong to the world ([Physics](09-physics.md)).
+
+### What each layer defines
+
+| Layer     | What it defines                                          | The rule that is not obvious                                                     |
+| --------- | -------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| Purpose   | Why the agent exists — mission plus the scope it owns    | A north star, not a task list: it is what a learning agent is anchored to        |
+| Values    | What the agent stands for — core principles              | Character traits it upholds, never behavioural constraints                       |
+| Bonds     | Who the agent trusts — operators and peers, with a level | Bonds survive forks, so a clone is never orphaned from its chain of accountability |
+| Role      | Who the agent is — role, style, operating preferences    | Identity, not chains: the agent may deviate on judgment                          |
+| Skills    | What the agent can do — self-contained capabilities      | Each carries a trigger, required context, steps, and a rollback                  |
+| Knowledge | What the agent knows — facts, stack, conventions         | World-scoped rather than agent-scoped; mutable and queryable                     |
+| Playbooks | How the agent acts — a "when" clause plus numbered steps | Hand-written or auto-discovered from journal patterns ([ADR-002](decisions/002-defer-instincts-layer.md)) |
+| Journal   | What the agent experienced — one file per session        | Appended by the system: world ID, image, outcome, exit code, duration            |
+
+### Skills, playbooks, and knowledge
+
+The three memory-adjacent layers look alike and are not:
+
+|              | Skills                     | Playbooks                        | Knowledge                  |
+| ------------ | -------------------------- | -------------------------------- | -------------------------- |
+| Purpose      | Define a capability        | Record a procedure               | Store facts                |
+| Triggered by | Operator request or event  | A situation that matches         | Query or reference         |
+| Structure    | Trigger, steps, rollback   | When, then steps                 | Free-form facts            |
+| Mutability   | Versioned, hand-authored   | Hand-authored or auto-discovered | Continuously updated       |
+| In one line  | "I can deploy"             | "When I deploy, I do X, Y, Z"    | "The deploy target is AWS" |
+
+## Soul and Mind
+
+The Soul is the identity layer: purpose, values, bonds. The Mind is everything that changes: skills, knowledge, playbooks, journal. The split is behavioural.
+
+|              | Soul                             | Mind                                     |
+| ------------ | -------------------------------- | ---------------------------------------- |
+| Changes      | Never, or rarely and with intent | Constantly: grows, prunes, restructures  |
+| During Sleep | Untouched                        | Consolidated, pruned, reorganised        |
+| During Fork  | Shared across all forks          | Each fork gets its own copy              |
+| During Merge | No conflict possible             | Needs conflict resolution                |
+
+Because Claude Code is the runtime spawned inside the world ([ADR-004](decisions/004-claude-code-as-runtime.md)), these files are read natively as markdown: `SOUL.md` and `AGENTS.md` shape identity the way `.claude/agents/` does, `playbooks/` the way `.claude/skills/` does. There is no custom loader.
+
+## Lifecycle and mount
+
+The Architect creates a world, mounts the agent's profile into it, and generates the world's physics and faculties; the container-side gate spawns the agent CLI. The agent reads identity, skills, and knowledge to know who it is, then physics and faculties to know what is possible, and works — following playbooks, invoking skills, appending to the journal — until the world is destroyed.
+
+The profile outlives the world. The mount is read-write: the agent writes knowledge as it learns, appends to the journal, and creates a playbook when it finds a repeatable procedure ([Worlds](08-worlds.md) for the mount mechanics).
+
+## Dream — learning from one task
+
+Dream is the incremental cycle, one task at a time: the agent executes a task and appends to its journal, reviews those entries, distils patterns into candidate playbooks or knowledge updates, and promotes the high-confidence ones with an `auto-discovered: true` tag. The next task starts from the promoted playbook. It is Reflexion (Shinn et al., 2023) applied to a persistent filesystem.
+
+The framework supplies the primitives — snapshot, fork, merge — and the reflection logic runs as an agent-level feature on top.
+
+## Sleep — restructuring the whole Mind
+
+An agent that only accumulates degrades: the journal grows unbounded, new learnings contradict old ones, outdated playbooks go unreviewed, the self-model drifts. Sleep is the phase where the agent steps back from execution and restructures the entire Mind. Four operations, plus one optional:
+
+1. **Consolidate** — compress journal entries into knowledge: raw detail fades, lessons persist.
+2. **Prune** — retire low-confidence playbooks, remove stale knowledge.
+3. **Reorganise** — merge related playbooks, resolve contradictions.
+4. **Update the self-model** — revise the agent's own understanding of its strengths and weaknesses.
+5. **Dream** (optional) — cross-reference disparate experiences for non-obvious patterns.
+
+Sleep has depth: a nap compresses recent entries after a few tasks, light sleep prunes and consolidates after a day's work, deep sleep runs the full restructuring including the dream — weekly, or after a milestone. The Soul is the fixed point through all of it: Sleep can reorganise knowledge and playbooks completely and the agent stays recognisably itself.
+
+### Open question: the Sleep execution model
+
+Undecided — should Sleep run inside a world (the agent restructures its own Mind through the runtime: consistent and creative, but slow and token-hungry), outside it (a framework process over the profile directory: fast and deterministic, but unable to resolve semantic contradictions), or as a hybrid (the framework does journal compression and dedup, the agent does contradictions, self-model, and dreaming)? Leaning toward the hybrid: mechanical consolidation does not need an LLM; semantic restructuring does.
+
+## Versioning a Mind
+
+Memory is versioned the way code is: snapshot, fork, merge, rollback. This is what lets an agent try a risky approach without corrupting what it knows, run two strategies in parallel, or hand an experienced Mind to a new agent.
+
+| Operation | What it does                                              | Effect on the Soul            |
+| --------- | --------------------------------------------------------- | ----------------------------- |
+| Snapshot  | Captures a Mind at a point in time; immutable afterwards  | Not included, always current  |
+| Fork      | Copies a Mind so it can diverge; the original is untouched | Inherited, shared not copied  |
+| Merge     | Applies one branch's changes into another                 | No conflict possible          |
+| Rollback  | Restores a Mind to a snapshot, discarding what came after | Untouched                     |
+
+Two forks of one agent share the same Soul, so however far they diverge in knowledge and skill they remain the same agent — they diverged in how they operate, not in why they exist.
+
+Versioning is per agent, not per world: each agent with a Mind branches independently, which is what makes specialisation practical (fork a general-purpose worker into domain specialists and let each evolve) and what makes a failed approach cheap (roll one agent's Mind back to a known-good state without touching its peers in the same world).
+
+### Merging
+
+| Conflict  | Resolution                                                                |
+| --------- | ------------------------------------------------------------------------- |
+| Knowledge | Keep the most recent version, or have the agent reconcile the two         |
+| Playbook  | Keep both as alternatives and let the agent choose on context             |
+| Journal   | No conflict possible: journals are append-only, so a merge is concatenation |
+
+Undecided — which of those becomes the default when two branches touched the same file: last-write-wins (simple, loses one side), agent-mediated merge (intelligent, non-deterministic, costs a model call), keep-both (no loss, duplicates accumulate), or human resolution (best quality, does not scale). Leaning toward agent-mediated for knowledge, keep-both for playbooks, concatenation for the journal.
+
+### What is shipped
+
+Dream, Sleep, and Fork ship today (`spwn agent dream|sleep|fork`), built on filesystem snapshots. Merge and richer branching are ahead; content-addressable storage is a later option if the snapshots get expensive.
+
+Designed, not shipped: agents that fork, experiment, and merge without an operator in the loop.
+
+## Future: the instincts layer
+
+A fourth memory type — instincts, the implicit patterns that emerge from repeated experience — is planned for v2. Until then auto-discovered patterns live in `playbooks/` behind the `auto-discovered: true` tag ([ADR-002](decisions/002-defer-instincts-layer.md)).
+
+## Related
+
+- [Concepts](02-concepts.md) — Soul, Memory, Dream, Sleep, Fork in one line each.
+- [Primitives](04-primitives.md) — the agent directory and `agent.yaml`.
+- [Worlds](08-worlds.md) — how the profile is mounted and what persists.

--- a/docs/11-observatory.md
+++ b/docs/11-observatory.md
@@ -1,0 +1,23 @@
+# Observatory
+
+The Observatory is the web face of spwn: every active world and agent at a glance, chat with them, and lifecycle actions from the interface. Where the CLI is the scripting surface, this is the monitoring and interactive one. Open it with `spwn web`.
+
+## Shape
+
+A Next.js application ([`apps/web`](../apps/web)) backed by a Go API server ([`apps/api`](../apps/api)) that reads and writes the spwn filesystem directly and calls the same domain packages the CLI consumes, behind HTTP. Where those two sit in the layer graph is [Architecture](05-architecture.md).
+
+## Design principles
+
+- **Read-write, not read-only.** Full CRUD over worlds and agents — spawn, snapshot, destroy, browse and edit a Mind — not a metrics viewer.
+- **The filesystem is the truth.** Views are computed live from the same on-disk state the CLI uses: no shadow database, no background workers.
+- **CLI parity.** Every action available in the CLI is reachable from the dashboard; the CLI stays the primary surface for scripting and automation.
+- **Zero friction.** Dependencies that are not running are started when needed, and failures come with an actionable hint.
+
+## Designed, not shipped
+
+The long-term target is an isometric, real-time visualisation of worlds and the agents working inside them, fed by runtime event streaming ([ADR-008](decisions/008-rivet-runtime-layer.md)). Today the dashboard is the flat web UI described above.
+
+## Related
+
+- [CLI](03-cli.md) — the other operator surface.
+- [Architecture](05-architecture.md) — `apps/web` and `apps/api` in the monorepo layout.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,13 +8,18 @@ The written corpus for spwn — knowledge lives here exactly once. The root [`AG
 2. [Concepts](02-concepts.md) — domain model, vocabulary, IDs, evolution.
 3. [CLI](03-cli.md) — grammar + command map (per-command pages generated in [`cli/`](cli/)).
 4. [Primitives](04-primitives.md) — `spwn.yaml`, agents, tools, skills, hooks, commands, the dep grammar.
-5. [Architecture](05-architecture.md) — monorepo layout, layered dependency graph, DooD, code style.
+5. [Architecture](05-architecture.md) — monorepo layout, layered dependency graph, DooD, non-goals, code style.
 6. [Gate](06-gate.md) — host-side broker: cookies, MCP routing, browser sidecar (experimental).
 7. [Testing](07-testing.md) — strategy, layer pyramid, running the suites.
+8. [Worlds](08-worlds.md) — how a world runs, the Backend port, what crosses the boundary.
+9. [Physics](09-physics.md) — constants, laws, elements, and the world context an agent reads.
+10. [The Mind](10-mind.md) — identity, skills, memory; Dream, Sleep, and versioning a Mind.
+11. [Observatory](11-observatory.md) — the web UI and the API behind it.
 
 ## Topic references
 
 - [Automations](automations.md) · [Recipes](recipes.md) · [Dependency catalog](dependency-catalog.md)
+- [`decisions/`](decisions/README.md) — the decision records: why the stack, the layering, the container model.
 - [`cli/`](cli/) — generated Cobra man pages (regenerate with `make docs`).
 - [`contributing/`](contributing/) — release runbook, self-update system.
 - [`notes/`](notes/) — design rationale and audits. · [`qa/`](qa/) — manual QA passes.

--- a/docs/decisions/001-gate-over-socket.md
+++ b/docs/decisions/001-gate-over-socket.md
@@ -1,0 +1,65 @@
+# ADR-001: Gate Abstraction Over Direct Transport
+
+**Date:** 2025-02-05
+**Status:** Accepted
+
+## Context
+
+The SDK needs to communicate with processes running inside Universes. Docker provides `docker exec` and the Docker API for this, but if the SDK communicates directly using Docker-specific transports, it becomes tightly coupled to the backend. We need to decide whether to expose raw transports or abstract them behind a unified protocol.
+
+## Decision
+
+We introduce the **Gate**—an abstraction layer that sits between the SDK and the transport. The SDK always talks to a Gate. The Gate translates to the appropriate transport for the active backend.
+
+```
+┌──────────┐       ┌──────────┐       ┌──────────────┐
+│   SDK    │──────►│   Gate   │──────►│   Backend    │
+│          │       │          │       │  (transport) │
+│ exec()   │       │ encode   │       │  docker exec │
+│ read()   │       │ route    │       │              │
+│ write()  │       │ decode   │       │              │
+└──────────┘       └──────────┘       └──────────────┘
+```
+
+The Gate defines a small set of **message types**:
+
+| Message Type | Direction       | Purpose                                       |
+| ------------ | --------------- | --------------------------------------------- |
+| `exec`       | Host → Universe | Run a command, return stdout/stderr/exit code |
+| `file_read`  | Host → Universe | Read a file from the Universe filesystem      |
+| `file_write` | Host → Universe | Write a file to the Universe filesystem       |
+| `signal`     | Host → Universe | Send a signal to a running process            |
+| `heartbeat`  | Bidirectional   | Keep-alive, health check                      |
+| `stream`     | Universe → Host | Real-time output from a running command       |
+
+## Rationale
+
+The Gate is a thin layer—it adds minimal overhead but provides critical decoupling. This is the same pattern as database drivers (SQL is the gate, the driver handles transport) or HTTP (the protocol is the gate, TCP/TLS is the transport). The abstraction keeps the door open for future backends without changing agent code.
+
+## Consequences
+
+### Positive
+
+- **Backend portability.** Agent code doesn't depend on Docker directly.
+- **Testability.** Mock the Gate for unit testing agents without spinning up containers.
+- **Extensibility.** New backends only need a transport adapter, not SDK changes.
+- **Structured communication.** Message types enforce a contract—no more parsing raw shell output for control flow.
+
+### Negative
+
+- **Abstraction cost.** The Gate adds a translation step. For Docker exec, this is nearly zero.
+- **Least common denominator.** Features unique to one transport (e.g., Docker API's container stats) aren't exposed through the Gate unless explicitly added.
+
+### Mitigations
+
+- Keep the Gate protocol minimal—only the operations agents actually need.
+- Allow escape hatches for backend-specific features when needed.
+
+## Alternatives Considered
+
+| Alternative                 | Why Rejected                                                  |
+| --------------------------- | ------------------------------------------------------------- |
+| **Direct transport access** | SDK code becomes backend-specific, breaks on migration        |
+| **gRPC**                    | Heavy dependency, overkill for the message set                |
+| **REST over TCP**           | Requires networking setup in every Universe                   |
+| **Custom binary protocol**  | Harder to debug, no ecosystem tooling, premature optimization |

--- a/docs/decisions/002-defer-instincts-layer.md
+++ b/docs/decisions/002-defer-instincts-layer.md
@@ -1,0 +1,72 @@
+# ADR-002: Defer Instincts Layer to v2
+
+**Date:** 2025-02-10
+**Status:** Accepted
+
+## Context
+
+During Mind framework design, we identified four types of agent memory:
+
+| Type          | Academic Term       | Purpose                      |
+| ------------- | ------------------- | ---------------------------- |
+| Knowledge     | Semantic memory     | Facts and understanding      |
+| Playbooks     | Procedural memory   | How-to instructions          |
+| Journal       | Episodic memory     | What happened                |
+| **Instincts** | **Implicit memory** | **Auto-discovered patterns** |
+
+Instincts are behavioral patterns that emerge from repeated experience — things the agent "just knows" without explicit instruction. For example, an agent that has debugged 50 Node.js projects might develop an instinct to always check `node_modules` freshness first.
+
+The question: should we add a fourth agent profile directory (`instincts/`) in v1?
+
+## Decision
+
+**Defer the instincts layer to v2.** In v1, auto-discovered patterns are stored in `playbooks/` with an `auto-discovered: true` frontmatter tag.
+
+```yaml
+# playbooks/check-node-modules-freshness.md
+---
+auto-discovered: true
+confidence: 0.82
+source: journal analysis (2025-02-15)
+---
+When debugging a Node.js build failure, first check if node_modules
+is stale by comparing package-lock.json mtime to node_modules mtime.
+```
+
+When the volume and sophistication of auto-discovered patterns justifies a dedicated directory, we promote `instincts/` in v2.
+
+## Rationale
+
+Three directories is the right starting point:
+
+1. **We don't know the shape of instincts yet.** Are they playbook fragments? Weighted heuristics? Behavioral policies? We need real-world data before committing to a structure.
+2. **Premature abstraction is costly.** Adding a directory is easy. Removing one (and migrating content) is hard.
+3. **The tag approach is flexible.** `auto-discovered: true` lets us query and filter without structural commitment.
+4. **Trinity is elegant.** Knowledge/Playbooks/Journal maps cleanly to semantic/procedural/episodic memory. Adding a fourth weakens the metaphor unless it earns its place.
+
+## Consequences
+
+### Positive
+
+- Simpler v1 — three directories, three concepts, easy to explain.
+- Auto-discovered patterns still have a home (playbooks with a tag).
+- We gather real data before designing the instincts structure.
+
+### Negative
+
+- Playbooks directory may accumulate noise as auto-discovered entries mix with hand-written ones.
+- The `auto-discovered` tag is informal — no schema enforcement in v1.
+
+### Mitigations
+
+- Naming convention: auto-discovered playbooks use a `_auto-` prefix in the filename.
+- When playbooks/ has more than 20 auto-discovered entries, revisit this ADR.
+
+## Alternatives Considered
+
+| Alternative                | Why Rejected                                                              |
+| -------------------------- | ------------------------------------------------------------------------- |
+| **Add `instincts/` now**   | Premature — we don't know the right structure yet                         |
+| **Store in `journal/`**    | Journal is chronological; instincts are derived patterns, not events      |
+| **Store in `knowledge/`**  | Knowledge is factual; instincts are behavioral — different category       |
+| **Flat file in Mind root** | Unstructured, doesn't scale, breaks the directory-per-memory-type pattern |

--- a/docs/decisions/004-claude-code-as-runtime.md
+++ b/docs/decisions/004-claude-code-as-runtime.md
@@ -1,0 +1,70 @@
+# ADR-004: Claude Code CLI as Agent Runtime
+
+**Date:** 2026-02-28
+**Status:** Accepted
+
+## Context
+
+Spwn needs an agent runtime—the component that reads the Mind, understands the Physics, and autonomously operates inside a universe. The original design assumed we'd build custom AI logic: a TypeScript SDK wrapping LLM API calls with tool-use loops, context management, and session handling.
+
+But Claude Code already mastered this. It reads markdown files natively. It has `bash`. It composes Unix commands. It manages its own context window. It persists sessions. It's exactly the runtime we'd spend months building—and it already works.
+
+The question became: why build another runtime when the best one already exists?
+
+## Decision
+
+Use Claude Code CLI as the agent runtime spawned inside universes. Spwn's job is **reality infrastructure**—creating universes, managing agents (their Minds, physics, faculties), defining physics, bridging faculties. Claude Code's job is **thinking and acting** inside that reality.
+
+The architecture:
+
+1. **Architect** creates a universe (Docker container)
+2. **Architect** mounts the Mind at `/mind` and workspace at `/workspace`
+3. **Architect** generates `physics.md` describing available tools and faculties
+4. **Container-side Gate** spawns Claude Code CLI via ACP (Agent Client Protocol)
+5. **Claude Code** reads the Mind (personas, skills, knowledge, playbooks) as markdown—its native format
+6. **Claude Code** reads `physics.md` to understand the environment
+7. **Claude Code** operates autonomously using bash, files, and all available tools
+8. **Claude Code** writes to the journal as it works
+9. **Spwn** manages session persistence across container lifecycle
+
+### Session Persistence
+
+The container-side Gate manages sessions via ACP's `session/load` and `session/new`. Spwn manages session IDs so that an agent re-entering a universe (or entering a new one with the same Mind) can continue from where it left off. See [the ACP adoption decision](./006-acp-inside-container.md).
+
+### Mind ↔ Claude Code Mapping
+
+The agent profile directory structure maps naturally to Claude Code's conventions:
+
+| Mind Directory | Claude Code Equivalent         | How Claude Code Uses It            |
+| -------------- | ------------------------------ | ---------------------------------- |
+| `personas/`    | `.claude/agents/`              | System-level identity and behavior |
+| `skills/`      | `.claude/skills/`              | Invocable capabilities             |
+| `knowledge/`   | `CLAUDE.md`                    | Context and facts                  |
+| `playbooks/`   | `.claude/skills/` (procedural) | Step-by-step procedures            |
+| `journal/`     | —(Spwn-specific)               | Append-only experience log         |
+
+## Consequences
+
+### What Becomes Easier
+
+- **No custom agent logic.** We don't build, debug, or maintain an AI reasoning engine.
+- **Instant capability.** Claude Code already handles tool use, error recovery, multi-step planning, and context management.
+- **Native markdown consumption.** Mind files are markdown—Claude Code reads them without any custom loader.
+- **Session management.** Claude Code's `--resume` provides session persistence out of the box.
+- **Ecosystem alignment.** Claude Code is actively maintained by Anthropic. We ride their improvements for free.
+
+### What Becomes Harder
+
+- **Vendor coupling.** Spwn depends on Claude Code CLI being available and maintained.
+- **Multi-model support.** Supporting other CLI agents (Codex CLI, Gemini CLI) needed an abstraction layer; [the ACP adoption decision](./006-acp-inside-container.md) supplied it, so swapping agent CLIs is a container image change.
+- **Fine-grained control.** We can't control Claude Code's internal reasoning—only what we put in the environment.
+- **Licensing.** Claude Code's license terms apply inside universes.
+
+## Alternatives Considered
+
+| Alternative                      | Why Rejected                                                                                            |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| **Custom TypeScript agent SDK**  | Months of work to build what Claude Code already does. We'd be a worse version of it.                   |
+| **Raw LLM API calls**            | No session management, no tool use loop, no context management. We'd rebuild Claude Code from scratch.  |
+| **LangChain/CrewAI integration** | Tool-call frameworks—the exact paradigm Spwn replaces. They chain functions; we give agents a computer. |
+| **Model-agnostic agent loop**    | Attractive in theory but Claude Code's Unix mastery is unmatched. Build for the best, abstract later.   |

--- a/docs/decisions/005-go-core.md
+++ b/docs/decisions/005-go-core.md
@@ -1,0 +1,74 @@
+# ADR-005: Go for Core Library
+
+**Date:** 2026-02-28
+**Status:** Accepted
+
+## Context
+
+Spwn needs a core implementation language for the business logic: lifecycle management, Mind management, physics generation, element bridging, and backend orchestration. The original design used TypeScript, then briefly Rust. With the pivot to Claude Code as the agent runtime (ADR-004), the primary workload is Docker orchestration + CLI — not performance-critical computation.
+
+This is infrastructure glue. The right language for Docker orchestration is the one the Docker ecosystem is built in.
+
+## Decision
+
+Use Go for the core library and CLI. The architecture follows the `containerd` model:
+
+```
+┌────────────────────────┐  ┌──────────────────────────┐
+│     spwn CLI            │  │       Thin SDKs           │
+│  (Go, cobra — primary   │  │  (TS, Python — ~50 lines) │
+│   interface)            │  │   Import domains directly  │
+└───────────┬─────────────┘  └────────────┬─────────────┘
+            │                             │
+            └──────────┬──────────────────┘
+                       ▼
+┌──────────────────────────────────────────────────────┐
+│               Domain Modules                          │
+│     (Go modules — each with public API + internal/)   │
+│  core/universe · core/agent · core/gate                │
+└──────────────────────────────────────────────────────┘
+```
+
+### Why Go
+
+| Factor                | Go                             | Rust                              | TypeScript              |
+| --------------------- | ------------------------------ | --------------------------------- | ----------------------- |
+| **Docker SDK**        | Official (docker/docker)       | bollard (third-party)             | dockerode (third-party) |
+| **Ecosystem fit**     | Docker, containerd, K8s—all Go | Third-party wrappers              | Third-party wrappers    |
+| **Compilation speed** | ~2s                            | ~30s+                             | N/A                     |
+| **Single binary**     | Yes                            | Yes                               | No (needs Node.js)      |
+| **Concurrency**       | Goroutines—simple, powerful    | tokio—powerful but ceremony-heavy | Event loop              |
+| **Contributor pool**  | Large                          | Small                             | Large                   |
+| **Distribution**      | `go install` or single binary  | `cargo install` or single binary  | `npm install`           |
+
+### Key Go Dependencies
+
+| Package         | Purpose                             |
+| --------------- | ----------------------------------- |
+| `docker/docker` | Docker Engine API client (official) |
+| `spf13/cobra`   | CLI argument parsing                |
+| `google/uuid`   | UUID generation                     |
+
+## Consequences
+
+### What Becomes Easier
+
+- **Docker integration.** Official SDK, first-party documentation, same language as Docker itself.
+- **Fast iteration.** 2-second builds vs 30+ seconds with Rust. Rapid prototyping.
+- **Single binary distribution.** `spwn` is one binary—no runtime.
+- **Contributors.** Go is widely known, lower barrier to entry.
+- **Concurrency.** Goroutines are natural for container lifecycle management.
+
+### What Becomes Harder
+
+- **FFI for SDKs.** cgo is more complex than Rust's C ABI, adding friction for TS/Python bindings.
+- **Type safety.** Go's type system is weaker than Rust's. No sum types, no ownership model.
+- **Error handling.** Go's error returns are easy to accidentally ignore (though `errcheck` linter helps).
+
+## Alternatives Considered
+
+| Alternative    | Why Rejected                                                                                                                                                 |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Rust**       | Excellent language, but adds unnecessary complexity (async-trait, lifetimes, slow compilation) for what is Docker API orchestration. Third-party Docker SDK. |
+| **TypeScript** | Requires Node.js runtime. Not suitable as infrastructure. Can't produce a single binary.                                                                     |
+| **Python**     | Not suited for infrastructure. GIL, no single binary, slow.                                                                                                  |

--- a/docs/decisions/006-acp-inside-container.md
+++ b/docs/decisions/006-acp-inside-container.md
@@ -1,0 +1,84 @@
+# ADR-006: Agent Client Protocol Inside the Container
+
+**Date:** 2026-03-01
+**Status:** Accepted
+
+## Context
+
+Spwn needs a standardized way to communicate with the agent CLI running inside a container. The current design has the Architect spawning Claude Code CLI directly inside the container and managing it via process signals and `--resume` flags. This works but is tightly coupled to Claude Code's specific CLI interface.
+
+The [Agent Client Protocol (ACP)](https://github.com/agentclientprotocol/agent-client-protocol) is a standardized JSON-RPC protocol (over stdio) between clients and coding agents. It supports session management, authentication, streaming, and tool permissions. 34+ agents support it, including Claude Code, Codex CLI, and Gemini CLI.
+
+The question: should Spwn build its own agent communication protocol, adopt ACP everywhere, or use ACP selectively?
+
+## Decision
+
+Run an ACP client **inside** the container, alongside the agent CLI. The Gate bridges between the container-side ACP client and the host-side Architect over TCP (`host.docker.internal`). Spwn only builds the Gate bridge protocol—not the agent communication protocol.
+
+The architecture:
+
+```
+Host                           │  Universe (container)
+                                    │
+Architect                           │
+  └── Gate (host-side)              │  Gate (container-side)
+       │                            │    │
+       └────── TCP (host.docker) ───│────┘
+                                    │    └── ACP Client
+                                    │         └── stdio → Agent CLI
+```
+
+1. **ACP client** runs inside the container—speaks stdio to Claude Code CLI (or any ACP-compatible agent)
+2. **Gate (container-side)** wraps the ACP client, handles local agent lifecycle
+3. **Gate (host-side)** runs on the Host, bridges requests from the Architect
+4. **TCP** connects the two Gate halves—the only thing that crosses the container boundary
+5. **Architect** speaks Spwn's own Gate protocol to the host-side Gate—never sees ACP directly
+
+### What ACP Gives Us for Free
+
+- **Session management**—`session/new`, `session/load`, `session/prompt`, resume across restarts
+- **Authentication**—`authenticate` flow handles API key setup
+- **Streaming**—`session/update` events for real-time agent output
+- **Tool permissions**—control what the agent can do programmatically
+- **Multi-agent support**—swap the agent CLI (Claude Code → Codex CLI → Gemini CLI) without changing the Gate protocol
+
+### What Spwn Builds
+
+- **Gate bridge protocol**—the wire format over TCP between host and container
+- **Element bridging**—MCP servers on the Host exposed as CLI commands (unchanged)
+- **Mount management**—Mind, workspace mounts (unchanged)
+- **Lifecycle orchestration**—the Architect still creates/destroys universes (unchanged)
+
+### Container Image
+
+A custom base image ships with:
+
+- Ubuntu 24.04 base
+- Claude Code CLI pre-installed
+- Container-side Gate binary (Rust, using the official `agent-client-protocol` crate)
+- Ready to communicate on container start—no setup delay
+
+## Consequences
+
+### What Becomes Easier
+
+- **Multi-agent support.** Swapping Claude Code for Codex CLI or Gemini CLI is a container image change, not a protocol change. ACP abstracts the agent interface.
+- **Session management.** ACP handles session create/load/resume natively. No custom `--resume` flag management.
+- **Streaming output.** ACP's `session/update` events give real-time agent output through the Gate without custom log tailing.
+- **Authentication.** ACP's `authenticate` flow handles API key setup inside the container.
+- **Ecosystem alignment.** ACP is becoming the standard for agent communication. 34+ agents support it today.
+
+### What Becomes Harder
+
+- **Additional dependency.** ACP client and protocol add complexity inside the container image.
+- **Protocol translation.** The Gate must translate between Spwn's protocol and ACP—two wire formats to maintain.
+- **ACP evolution.** If ACP changes significantly, the container-side client must be updated.
+
+## Alternatives Considered
+
+| Alternative                       | Why Rejected                                                                                                                                                                                                               |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Adopt ACP end-to-end**          | Would make the Architect an ACP client directly. But ACP is designed for editor-to-agent communication, not orchestrator-to-container. The Gate protocol handles concerns ACP doesn't (mounts, element bridging, physics). |
+| **Build custom agent protocol**   | Months of work to standardize what ACP already provides. We'd miss the 34+ agent ecosystem.                                                                                                                                |
+| **Direct CLI spawning (current)** | Works for Claude Code but breaks when switching agents. No standard session/streaming/auth interface.                                                                                                                      |
+| **ACP on the host only**          | Would require exposing ACP through the container boundary directly, complicating the security model. Gate-as-bridge keeps the boundary clean.                                                                              |

--- a/docs/decisions/007-rust-container-gate.md
+++ b/docs/decisions/007-rust-container-gate.md
@@ -1,0 +1,59 @@
+# ADR-007: Rust for the Container-Side Gate
+
+**Date:** 2026-03-01
+**Status:** Accepted
+
+## Context
+
+The container-side Gate is a binary that runs inside the universe container. It speaks ACP (JSON-RPC over stdio) to the agent CLI, handles crash recovery, and communicates with the host-side Gate over TCP. The rest of Spwn is written in Go.
+
+The question: what language should the container-side Gate be written in?
+
+## Options Considered
+
+| Language       | ACP SDK                                | Binary Size     | Container Dependency | Trade-off                                                                                                          |
+| -------------- | -------------------------------------- | --------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| **Go**         | No official SDK                        | ~5-10 MB static | None                 | Same language as core, but must hand-roll ACP JSON-RPC client (~200-300 lines) and track protocol changes manually |
+| **Rust**       | Official `agent-client-protocol` crate | ~2-5 MB static  | None                 | Second language/toolchain, but full ACP implementation for free                                                    |
+| **TypeScript** | Official `@agentclientprotocol/sdk`    | ~50+ MB         | Node.js runtime      | Adds heavy runtime dependency to every container                                                                   |
+| **Python**     | Official `python-sdk`                  | ~30+ MB         | Python runtime       | Adds heavy runtime dependency to every container                                                                   |
+
+## Decision
+
+Use **Rust** with the official [`agent-client-protocol`](https://crates.io/crates/agent-client-protocol) crate.
+
+The container-side Gate lives at `platform/gate-runtime/` as a standalone Rust crate, built as a static binary (`spwn-gate`), and copied into the container image at build time.
+
+### Why Rust
+
+1. **Official ACP SDK.** The `agent-client-protocol` crate gives us the full ACP implementation—session management, streaming, authentication, JSON-RPC framing—without reimplementing it. Protocol changes upstream are absorbed via `cargo update`.
+
+2. **ACP is still evolving.** New methods, session semantics, and streaming changes arrive regularly. With Go, we'd track and reimplement each change manually. With Rust, we update the crate.
+
+3. **Small static binary.** ~2-5 MB, zero runtime dependencies. Ideal for containers where image size matters.
+
+4. **Clean boundary.** The container-side Gate communicates with the host-side Gate over TCP. It doesn't share code, types, or state with the Go codebase. It's a self-contained binary with a well-defined interface—more like a dependency than a module.
+
+5. **Minimal surface area.** The container-side Gate does exactly three things: speak ACP to the agent CLI, supervise the agent process, and listen for commands from the host-side Gate. It's small enough that the second-language cost is negligible.
+
+### Why Not Go
+
+Go would keep the project as a single language. But the container-side Gate is the one place where ACP protocol fidelity matters most—it's the component that spawns agents, manages sessions, handles streaming, and recovers from crashes. Reimplementing ACP's JSON-RPC protocol in Go (~200-300 lines) is achievable, but tracking upstream protocol changes manually introduces ongoing maintenance burden and risk of incompatibility.
+
+## Consequences
+
+### What Becomes Easier
+
+- **Protocol fidelity.** The official SDK is always correct and up-to-date with ACP spec changes.
+- **Maintenance.** `cargo update` absorbs ACP protocol evolution. No manual JSON-RPC tracking.
+- **Container image.** Smaller binary than Go equivalent. No runtime dependencies.
+
+### What Becomes Harder
+
+- **Two build toolchains.** `go build` for the core + `cargo build` for the container-side Gate. CI must handle both.
+- **Developer onboarding.** Contributors need both Go and Rust toolchains installed.
+- **Code sharing.** Types and constants can't be shared between Go core and Rust gate. The TCP wire format is the contract.
+
+### Mitigation
+
+The container-side Gate is intentionally small and isolated. The Rust surface area is one crate with one binary. The boundary is TCP with a simple HTTP wire format. Most development happens in the Go core—the Rust gate is built once and updated primarily when ACP evolves.

--- a/docs/decisions/008-rivet-runtime-layer.md
+++ b/docs/decisions/008-rivet-runtime-layer.md
@@ -1,0 +1,41 @@
+# ADR-008: Rivet Sandbox Agent SDK as the Runtime Normalization Layer
+
+**Status:** Accepted
+**Date:** 2026-03-29
+
+## Context
+
+Spwn supports multiple agent runtimes (Claude Code via ACP, Pi SDK via RPC, Codex via AppServer, OpenCode via ACP) and multiple providers (Anthropic, OpenAI, Google, Bedrock, Groq, Mistral, OpenRouter, Ollama). Without a normalization layer, the Gate, Governor, CLI, and Observatory would each need to understand every runtime's protocol and event format.
+
+The current container-side Gate speaks raw ACP to a single agent CLI. This works for Epoch 3 (Body) but does not scale to multi-runtime, multi-agent universes.
+
+## Decision
+
+Adopt the **Rivet Sandbox Agent SDK** as the runtime normalization layer inside universe containers.
+
+Rivet wraps all agent runtimes behind one consistent API:
+
+- **Event streaming**: unified event format regardless of which runtime powers the agent.
+- **Session persistence**: consistent session management across all runtimes.
+- **Audit**: structured logging of all agent actions.
+- **Runtime abstraction**: the Gate, Governor, and Observatory see one API regardless of whether the agent uses Claude Code (ACP), Pi (RPC), or Codex (AppServer).
+
+## Consequences
+
+### Positive
+
+- **Single integration point**: the Gate only needs to speak to Rivet, not to each runtime individually.
+- **Mixed runtimes per universe**: a Governor on Claude Opus and Citizens on GPT-4 or Sonnet all look identical to the orchestration layer.
+- **Observatory compatibility**: Rivet's event stream powers the real-time dashboard without runtime-specific adapters.
+- **Future-proof**: new runtimes are added as Rivet adapters, not as Gate protocol changes.
+
+### Negative
+
+- **Additional abstraction layer**: Rivet adds latency and complexity between the Gate and the agent runtime.
+- **Dependency**: Rivet becomes a critical dependency. If it has bugs, all runtimes are affected.
+
+### Migration
+
+- Epoch 3 (Body) continues using raw ACP directly.
+- Epoch 4 (Runtimes) introduces Rivet as a wrapper around ACP, then extends it to support Pi, Codex, and OpenCode.
+- The Gate protocol between host-side and container-side remains unchanged.

--- a/docs/decisions/009-zeroclaw-as-claw.md
+++ b/docs/decisions/009-zeroclaw-as-claw.md
@@ -1,0 +1,47 @@
+# ADR-009: ZeroClaw as the Architect Daemon
+
+**Status:** Accepted
+**Date:** 2026-03-29
+
+## Context
+
+Spwn needs an always-on daemon (Architect) that:
+
+1. Receives tasks from multiple messaging channels (Telegram, Slack, WhatsApp, Discord, CLI).
+2. Creates and destroys universes.
+3. Routes tasks to Governors.
+4. Aggregates results and delivers them back through the originating channel.
+
+This is a long-running, resource-sensitive process that must be reliable and lightweight.
+
+## Decision
+
+Use **ZeroClaw** as the implementation for the Architect daemon.
+
+ZeroClaw is a <5MB Rust binary that supports 50+ messaging channels and multi-agent orchestration. It runs in its own Docker container with `/var/run/docker.sock` mounted, creating sibling world containers on the host's Docker daemon (Docker-out-of-Docker / DooD).
+
+Key properties:
+
+- **Tiny footprint**: <5MB binary, <5MB RAM at idle. Negligible resource overhead.
+- **Rust**: memory-safe, no garbage collector pauses, ideal for a long-running daemon.
+- **50+ channels**: Telegram, Slack, WhatsApp, Discord, and many more out of the box.
+- **Multi-agent orchestration**: built-in support for task routing and agent coordination.
+
+## Consequences
+
+### Positive
+
+- **Lightweight**: Architect adds negligible overhead to the host machine.
+- **Reliable**: Rust's memory safety guarantees prevent crashes from memory bugs.
+- **Channel breadth**: 50+ channels means users can interact with Claw from almost any platform.
+- **Docker socket mounting natural fit**: ZeroClaw runs in a container and creates sibling containers via the mounted Docker socket, matching Spwn's DooD isolation model.
+
+### Negative
+
+- **Rust dependency**: the Architect daemon is Rust while the rest of Spwn core is Go. Two languages in the stack.
+- **ZeroClaw coupling**: Spwn depends on an external project for the Architect daemon.
+
+### Alternatives Considered
+
+- **Custom Go daemon**: would unify the language stack but requires building messaging channel support from scratch.
+- **Node.js bot framework**: mature messaging support but heavier runtime and worse resource profile for an always-on daemon.

--- a/docs/decisions/010-pi-mono-multi-provider.md
+++ b/docs/decisions/010-pi-mono-multi-provider.md
@@ -1,0 +1,41 @@
+# ADR-010: Pi-mono as the Primary Multi-Provider Runtime
+
+**Status:** Accepted
+**Date:** 2026-03-29
+
+## Context
+
+Spwn agents need to run on different LLM providers: Anthropic, OpenAI, Google, Bedrock, Groq, Mistral, OpenRouter, Ollama (local), and more. Each provider has its own API, authentication, and streaming format. Without a multi-provider abstraction, each provider requires its own integration in the runtime layer.
+
+Additionally, some users authenticate via subscriptions (Claude Pro/Max, ChatGPT Plus) rather than API keys. Subscription auth requires OAuth flows that are distinct from API key auth.
+
+## Decision
+
+Use **Pi-mono** as the primary multi-provider runtime behind Rivet.
+
+Pi-mono provides:
+
+- **17+ providers**: Anthropic, OpenAI, Google, Bedrock, Groq, Mistral, OpenRouter, Ollama, and more.
+- **Subscription OAuth**: supports Claude Pro/Max, ChatGPT Plus, and other subscription-based auth.
+- **Embeddable SDK**: can be embedded inside the Rivet normalization layer.
+- **Unified streaming**: consistent streaming format across all providers.
+
+## Consequences
+
+### Positive
+
+- **Broad provider support**: 17+ providers out of the box, no per-provider integration work.
+- **Subscription auth**: users can use their existing Claude Pro or ChatGPT Plus subscriptions without managing API keys.
+- **Cost optimization**: Governors on expensive models (Opus), Citizens on cheaper models (Sonnet), NPCs on cheapest (Haiku)—all through the same runtime.
+- **Local models**: Ollama support means fully offline operation for privacy-sensitive environments.
+
+### Negative
+
+- **Dependency**: Pi-mono becomes a critical dependency for multi-provider support.
+- **Abstraction leaks**: provider-specific features (streaming format quirks, rate limits, token counting) may not be perfectly normalized.
+
+### Alternatives Considered
+
+- **Direct provider SDKs**: each provider integrated separately. Maximum control but massive maintenance burden.
+- **LiteLLM**: similar multi-provider abstraction but lacks subscription OAuth and embeddable SDK.
+- **OpenRouter only**: simpler single integration but adds a middleman for all API calls and doesn't support local models.

--- a/docs/decisions/011-ports-and-adapters.md
+++ b/docs/decisions/011-ports-and-adapters.md
@@ -1,0 +1,82 @@
+# ADR-011: Ports & Adapters (Trait-Driven Architecture)
+
+**Status:** Accepted
+**Date:** 2026-03-29
+
+## Context
+
+Spwn integrates with many external systems: container runtimes (Docker, K8s), LLM providers (Anthropic, OpenAI, Google), agent runtimes (Claude Code, Pi, Codex), messaging channels (Telegram, Slack), persistence layers (filesystem, databases), and tool ecosystems (MCP, built-in). The AI ecosystem changes monthly---new agent CLIs, new providers, new deployment targets appear constantly.
+
+A monolithic architecture that hard-codes these integrations becomes unmaintainable. Every new provider requires changes across the codebase. Every new runtime requires rewiring the lifecycle manager. The system becomes brittle and vendor-locked.
+
+## Decision
+
+**Every layer of spwn that touches an external system is defined as a port (Go interface) with swappable adapters (implementations).**
+
+We adopt a strict ports & adapters architecture with 8 ports:
+
+| Port         | What it abstracts                    | Default adapter       |
+| ------------ | ------------------------------------ | --------------------- |
+| **Backend**  | Where universes run                  | Docker                |
+| **Runtime**  | How agents think (agent loop)        | Claude Code (ACP)     |
+| **Provider** | Which LLM serves intelligence        | Anthropic             |
+| **Channel**  | How Architect talks to outside world | CLI                   |
+| **Memory**   | How Minds persist                    | Filesystem (markdown) |
+| **Store**    | How state is tracked                 | JSON file             |
+| **Tool**     | What agents can do                   | Built-in + MCP        |
+| **Skill**    | Reusable capabilities                | Local files           |
+
+### Rules
+
+1. **Core domain modules program against ports, never against concrete adapters.** The `universe` module calls `backend.Create()`, never `docker.CreateContainer()`.
+2. **Adapters are injected at startup.** The CLI or Architect daemon creates adapter instances and passes them to domain constructors.
+3. **Ports are Go interfaces defined in the domain that uses them.** The Backend port is defined in `core/universe`, not in a shared package.
+4. **One adapter per port at runtime.** No adapter chaining or middleware (simplicity first).
+5. **Manifests select adapters.** The `org.yaml`, `worlds/{name}.yaml`, and `profile.yaml` manifests declare which adapter to use for each port. Cascading overrides apply.
+
+### How Adapters Are Registered and Swapped
+
+Adapters are registered in the CLI's startup code (or Architect's startup code):
+
+```go
+// Adapter selection based on org.yaml defaults
+switch orgConfig.Defaults.Backend {
+case "docker":
+    backend = docker.NewBackend()
+case "k8s":
+    backend = k8s.NewBackend()
+}
+
+architect := universe.NewArchitect(backend, memory, store, skillSource)
+```
+
+Swapping an adapter means changing a manifest value and restarting. No code changes, no recompilation.
+
+## Consequences
+
+### Positive
+
+- **No vendor lock-in.** Switching from Docker to K8s, or from Anthropic to OpenAI, is a configuration change.
+- **Testability.** Every port can be mocked in tests. No Docker required for unit tests.
+- **Ecosystem growth.** Third parties can write adapters without modifying core spwn.
+- **Future-proof.** When a new agent CLI appears, implement the Runtime port. When a new cloud provider appears, implement the Backend port.
+- **Framework identity.** Spwn is a framework for orchestrating artificial life, not a product tied to specific vendors.
+
+### Negative
+
+- **Indirection.** One more layer between the caller and the implementation.
+- **Interface design burden.** Ports must be designed carefully---too narrow limits adapters, too wide leaks abstraction.
+- **Adapter parity.** Not all adapters will support all features. Need a capability negotiation pattern.
+
+### Risks
+
+- **Premature abstraction.** Some ports may only ever have one adapter. Mitigated by starting with defaults and only adding the port when a second adapter is needed.
+- **Leaky abstractions.** Docker-specific concepts leaking into the Backend port. Mitigated by designing ports from the domain's perspective, not the adapter's.
+
+## Alternatives Considered
+
+| Alternative                                      | Why rejected                                                                  |
+| ------------------------------------------------ | ----------------------------------------------------------------------------- |
+| **Plugin system (dynamic loading)**              | Adds complexity, Go's plugin support is limited, most users need 1-2 adapters |
+| **No abstraction (hard-code Docker, Anthropic)** | Vendor lock-in, untestable, brittle                                           |
+| **Middleware chains**                            | Over-engineering for our use case, adds latency and complexity                |

--- a/docs/decisions/012-organization-manifest.md
+++ b/docs/decisions/012-organization-manifest.md
@@ -1,0 +1,91 @@
+# ADR-012: Universe Manifest (`org.yaml`)
+
+**Status:** Accepted
+**Date:** 2026-03-29
+
+## Context
+
+As spwn scales from a single developer to teams and universes, several needs emerge:
+
+1. **Shared defaults.** Every world and agent in a universe should share the same provider, backend, and physics defaults without repeating them in every manifest.
+2. **Governance.** Universes need to enforce limits (max worlds, cost caps, allowed providers) and audit agent activity.
+3. **Shared skills.** Teams need a common set of skills (coding standards, deployment procedures) available to all agents.
+4. **Multi-channel Architect.** Architect needs to know which messaging channels to connect to and how to sync configuration.
+5. **Config versioning.** Configuration changes---both by humans and by Architect---should be versioned and auditable.
+
+Without a top-level manifest, these concerns are scattered across individual world and agent configs, duplicated, and hard to govern.
+
+## Decision
+
+**Introduce `org.yaml` as the top-level Universe manifest at `~/.spwn/org.yaml`.** It sits above worlds and agents in the configuration hierarchy.
+
+### Manifest Hierarchy (Cascading Overrides)
+
+```
+org.yaml          → Universe defaults (source of truth)
+  world.yaml      → Per-world overrides
+    profile.yaml     → Per-agent overrides
+```
+
+Each level inherits all settings from the level above and can override any of them. Resolution order: `profile.yaml` > `world.yaml` > `org.yaml` > built-in defaults.
+
+### What `org.yaml` Contains
+
+| Section            | Purpose                                                                |
+| ------------------ | ---------------------------------------------------------------------- |
+| `defaults.runtime` | Default runtime backend, provider, model, and auth for all agents      |
+| `defaults.backend` | Default Backend port adapter for all worlds                            |
+| `defaults.memory`  | Default Memory port adapter                                            |
+| `defaults.store`   | Default Store port adapter                                             |
+| `defaults.physics` | Default physics (constants, laws, elements) for all worlds             |
+| `skills`           | Shared skills available to all agents (marketplace, git, local)        |
+| `governance`       | Limits and policies (max-worlds, cost-limit, allowed-providers, audit) |
+| `claw.channels`    | Channel port adapters for Architect communication                      |
+| `claw.sync`        | Git sync configuration for `~/.spwn/`                                  |
+
+### Why Config Sync to Git
+
+Architect manages itself using spwn (dogfooding). The `claw.sync` section configures auto-sync of `~/.spwn/` to a git repository:
+
+- **User changes flow in.** A user edits `org.yaml` on GitHub. Architect pulls the change. Adapters reconfigure.
+- **Architect changes flow out.** Architect promotes a citizen, updates a profile.yaml. The change is pushed. Visible in git history.
+- **Rollback is trivial.** A bad configuration change is a `git revert` away.
+- **Audit trail.** Every configuration change---by human or by Architect---is a git commit with a timestamp and author.
+
+### Why Cascading Overrides
+
+The cascading model is chosen over flat configuration because:
+
+1. **DRY.** Set provider=anthropic once in `org.yaml`. 50 agents inherit it. Override one agent to use OpenAI.
+2. **Governance.** The org manifest is the authority. It can restrict what lower levels can override (e.g., `governance.allowed-providers` limits which providers agents can use).
+3. **Familiarity.** CSS cascading, Terraform variable precedence, Kubernetes admission controllers all use the same pattern.
+
+## Consequences
+
+### Positive
+
+- **Single source of truth.** One file governs the entire universe.
+- **Declarative governance.** Limits, policies, and audit are configuration, not code.
+- **Git-native.** Config sync makes all changes versioned and auditable.
+- **Composable.** org.yaml composes with the ports & adapters architecture---it declares which adapters to use at each level.
+- **Natural hierarchy.** Universe > World > Agent mirrors real organizational structure.
+
+### Negative
+
+- **New concept to learn.** Users must understand cascading overrides.
+- **Merge conflicts.** Multiple people editing org.yaml simultaneously can conflict.
+- **Complexity.** More configuration surface area.
+
+### Risks
+
+- **Over-governance.** Universes might lock down too aggressively, reducing agent autonomy. Mitigated by making governance optional---if omitted, no limits apply.
+- **Sync conflicts.** Architect and user editing org.yaml simultaneously. Mitigated by git merge semantics and clear ownership (Architect owns state files, users own policy files).
+
+## Alternatives Considered
+
+| Alternative                    | Why rejected                                                          |
+| ------------------------------ | --------------------------------------------------------------------- |
+| **No org-level config**        | Defaults duplicated across every world and agent. No governance.      |
+| **Environment variables only** | Not composable, not versionable, not auditable.                       |
+| **Database-backed config**     | Adds dependency, loses human readability, harder to version with git. |
+| **Flat config (no cascading)** | Every agent must specify every setting. Verbose and error-prone.      |

--- a/docs/decisions/013-dood-over-dind.md
+++ b/docs/decisions/013-dood-over-dind.md
@@ -1,0 +1,86 @@
+# ADR-013: Docker-out-of-Docker (DooD) over Docker-in-Docker (DinD)
+
+**Status:** Accepted
+**Date:** 2026-04-01
+
+## Context
+
+Spwn's Architect daemon runs in a Docker container and needs to create and manage World containers. Two approaches exist:
+
+1. **Docker-in-Docker (DinD)**: Run a full Docker daemon inside the Architect container. World containers are nested inside the Architect.
+2. **Docker-out-of-Docker (DooD)**: Mount the host's Docker socket (`/var/run/docker.sock`) into the Architect container. World containers are created as siblings on the host's Docker daemon.
+
+## Decision
+
+Use **Docker-out-of-Docker (DooD)**. The Architect container mounts `/var/run/docker.sock` and creates sibling containers on the host's Docker daemon.
+
+### How It Works
+
+```
+Host machine
+└── Docker daemon (one daemon, controls everything)
+    ├── Architect container (has /var/run/docker.sock mounted)
+    │   ├── spwn binary + core libraries
+    │   ├── ~/.spwn/ (mounted from host)
+    │   └── Connected: Telegram, Slack, Discord, CLI
+    ├── World: w-jupiter-02572 (sibling, created BY Architect)
+    ├── World: w-callisto-38907 (sibling, created BY Architect)
+    └── Observatory container (sibling, created BY Architect)
+```
+
+The Architect container runs with:
+
+```bash
+docker run -d \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v ~/.spwn:/root/.spwn \
+  --network spwn-net \
+  spwn/architect
+```
+
+### Two Deployment Modes
+
+The same code and same Backend port work in both modes:
+
+- **LOCAL MODE**: The `spwn` CLI runs directly on the host, talks to `docker.sock` natively, and creates World containers. No Architect container needed. Fast, zero overhead.
+- **HOSTED MODE**: The Architect container runs always-on, talks to the mounted `docker.sock`, and creates World containers. Supports multi-channel input (Telegram, Slack, Discord).
+
+### Inter-Container Communication
+
+All containers (Architect, Worlds, Observatory) join the `spwn-net` Docker bridge network. This enables:
+
+- Architect → World communication (task routing, lifecycle management)
+- World → World communication (if needed for multi-world orchestration)
+- Observatory → Architect event streaming (via WebSocket)
+
+### Shared State
+
+The `~/.spwn/` directory is mounted from the host into the Architect container. This ensures:
+
+- Agent profiles, world configs, and state persist across container restarts
+- The same config is accessible in both local and hosted modes
+- Config sync (git-based) works identically in both modes
+
+## Consequences
+
+### Positive
+
+- **Performance**: No nested Docker daemon overhead. World containers run at native speed with direct access to host resources (cgroups, storage drivers).
+- **Simplicity**: One Docker daemon to manage. Standard Docker tooling (`docker ps`, `docker logs`) shows all containers—Architect, Worlds, Observatory—as peers.
+- **Storage efficiency**: No copy-on-copy layering. Image layers are shared between sibling containers on the same daemon.
+- **Industry standard**: DooD is the established pattern for CI/CD systems (Jenkins, GitLab CI) and container orchestrators. Well-documented, well-understood.
+- **Debuggability**: `docker ps` on the host shows everything. No need to exec into the Architect container to inspect World containers.
+- **Two modes from one codebase**: The Backend port talks to `docker.sock` regardless of whether it's the CLI or the Architect calling it.
+
+### Negative
+
+- **Socket access = root-equivalent**: The Architect container can create any container on the host. Mitigated by the fact that the user explicitly opts in by running `spwn architect start`, and the Architect is trusted code.
+- **No nested isolation**: World containers share the host's Docker daemon. A malicious World container with Docker socket access could affect siblings. Mitigated by never mounting `docker.sock` into World containers—only the Architect has socket access.
+
+### Why Not DinD
+
+- **Complexity**: DinD requires `--privileged` mode or complex security configurations. It runs a full Docker daemon inside a container, doubling resource usage.
+- **Performance overhead**: Nested storage drivers (overlay-on-overlay) cause significant I/O degradation.
+- **Caching issues**: Image layers cannot be shared between the inner and outer Docker daemons, leading to redundant downloads and storage.
+- **Debugging difficulty**: World containers are invisible to the host's `docker ps`. Operators must exec into the Architect to inspect them.
+- **Fragility**: Inner Docker daemons can conflict with the outer daemon on cgroups, networking, and storage.

--- a/docs/decisions/014-filesystem-messenger.md
+++ b/docs/decisions/014-filesystem-messenger.md
@@ -1,0 +1,67 @@
+# ADR-014: Filesystem-Based Agent Messaging
+
+**Status:** Accepted
+**Date:** 2026-03-31
+
+The record was written at decision time; only these two lines are
+reconstructed, 2026-09-05, from the commit that carries it (`b824a17`,
+"docs: ADR-012 filesystem-based messenger", 2026-03-31) — the same day the
+message timestamps below were taken from.
+
+## Context
+
+Agents living in the same world need to communicate — governors need to delegate tasks, citizens need to report progress, and peers need to collaborate. We needed a messaging system that works inside Docker containers without external infrastructure.
+
+## Decision
+
+We implemented a **filesystem-based inbox system** at `/world/inbox/`. Each agent has their own inbox directory (`/world/inbox/{name}/`). Messages are JSON files written directly to the filesystem.
+
+### How it works
+
+- **Send**: Write a JSON file to `/world/inbox/{recipient}/msg-{id}.json`
+- **Check**: Read files from `/world/inbox/{your-name}/`
+- **Watch**: A polling daemon checks for new unread messages every 5 seconds and wakes agents via `spwn agent talk`
+
+### Message format
+
+```json
+{
+    "id": "msg-morpheus-20260331-083001-042",
+    "from": "morpheus",
+    "to": "neo",
+    "timestamp": "2026-03-31T08:30:01Z",
+    "type": "task",
+    "content": "Implement the webhook handler",
+    "status": "unread"
+}
+```
+
+## Alternatives Considered
+
+1. **Message broker (Redis/NATS)** — adds infrastructure dependency, heavier
+2. **Unix domain sockets** — complex, harder to debug, not persistent
+3. **HTTP API between agents** — needs a server per agent, networking overhead
+4. **Shared database (SQLite)** — single-writer lock contention
+
+## Consequences
+
+### Positive
+
+- Zero infrastructure — just files
+- Human-readable — `cat /world/inbox/neo/*.json`
+- Naturally persistent — survives container restart
+- Agents use normal tools (Read, Write) — no special SDK
+- Searchable with standard Unix tools (`grep`, `find`)
+
+### Negative
+
+- Polling-based (not real-time) — 5-second latency
+- No delivery guarantees (file write can fail silently)
+- No message ordering guarantees beyond timestamp
+- Scales poorly to thousands of messages (filesystem limits)
+
+## Future
+
+- Upgrade to inotify/fswatch for real-time notification
+- Add message acknowledgment (delivered → read → processed)
+- Consider SQLite for high-volume worlds

--- a/docs/decisions/015-lint-enforced-layering.md
+++ b/docs/decisions/015-lint-enforced-layering.md
@@ -1,0 +1,64 @@
+# ADR-015: Lint-Enforced Layered Imports
+
+**Date:** 2026-04-16
+**Status:** Accepted
+
+> **Retroactive record.** Written 2026-09-04 during the knowledge harvest,
+> from the enforcing commit (`6811986f`, "Enforce 5-layer architecture:
+> packages/pack/, depguard, docs", 2026-04-16) and the session memory of
+> the same date.
+
+## Context
+
+After the clean-slate reimplementation, the Go monorepo grew many domain
+packages whose boundaries existed only in prose. Nothing stopped a
+foundation package from importing a runtime package; layering violations
+were invisible until they calcified. The refactor that created
+`packages/pack/` (absorbing the pack schema, refs, and lockfile from
+`image/` and `project/`) forced the question: what keeps the boundaries
+honest afterwards?
+
+## Decision
+
+**Package imports flow downward only, and the rule is machine-enforced,
+never aspirational.** Three mechanisms, layered themselves:
+
+1. **Go `internal/`** — compiler-enforced visibility. Each module's
+   implementation hides under `internal/`; only the root API is importable.
+2. **depguard** (in `.golangci.yml`) — lint-time layer rules. Each layer
+   carries deny rules for every package above it, so an upward import
+   fails CI.
+3. **The layer diagram in the corpus** — the human-readable map
+   ([Architecture](../05-architecture.md)), rewritten as the roster churns.
+
+At decision time the roster had five layers (foundation → domain →
+project → build → runtime, with the CLI free above); it has since grown.
+The invariant is the **direction and the enforcement**, not the layer
+count: `.golangci.yml` and [Architecture](../05-architecture.md) own the
+current graph.
+
+## Consequences
+
+### Positive
+
+- **Boundaries survive refactors.** A violating import is a red build,
+  not a code-review hope.
+- **The map cannot lie silently.** When the lint config and the docs
+  disagree, CI notices the config side.
+- **Refactors get cheaper**—`packages/pack/` could absorb three scattered
+  concerns because the deny rules pinned what may depend on what.
+
+### Negative
+
+- **Two sources to keep aligned**: the depguard rules and the prose
+  diagram. The lint rules are the mechanical truth; the doc follows.
+- **Layer churn has a cost**—every roster change edits deny lists across
+  `.golangci.yml`.
+
+## Alternatives Considered
+
+| Alternative                     | Why Rejected                                                       |
+| ------------------------------- | ------------------------------------------------------------------ |
+| **Convention only (docs)**      | Was the status quo; violations accumulated invisibly               |
+| **Single Go module, no layers** | Loses compiler-enforced `internal/` boundaries between domains     |
+| **Import-graph test in Go**     | Hand-rolls what depguard already does inside the existing lint run |

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,33 @@
+# Decisions
+
+Why spwn is built the way it is. One record per decision, chronological, the
+title naming the thing it decides about. A chapter states what holds today; a
+record here states what was chosen, when, and what it cost.
+
+Numbers are historical and never reused. ADR-003 (security as physics) is
+absent on purpose: it is a decision about the product itself rather than about
+this codebase, and it lives in the spwn product knowledge corpus outside this
+repository.
+
+| Record                                                    | Decides                                                          |
+| --------------------------------------------------------- | ---------------------------------------------------------------- |
+| [001](001-gate-over-socket.md)                            | A gate abstraction between the SDK and the container transport   |
+| [002](002-defer-instincts-layer.md)                       | Instincts deferred to v2; auto-discovered patterns are playbooks |
+| [004](004-claude-code-as-runtime.md)                      | Claude Code CLI as the agent runtime spawned inside worlds       |
+| [005](005-go-core.md)                                     | Go for the domain packages and the CLI                           |
+| [006](006-acp-inside-container.md)                        | ACP as the protocol between the container-side gate and the CLI  |
+| [007](007-rust-container-gate.md)                         | Rust for the container-side gate binary                          |
+| [008](008-rivet-runtime-layer.md)                         | Rivet as the runtime normalization layer inside worlds           |
+| [009](009-zeroclaw-as-claw.md)                            | ZeroClaw as the Architect daemon                                 |
+| [010](010-pi-mono-multi-provider.md)                      | Pi-mono as the primary multi-provider runtime                    |
+| [011](011-ports-and-adapters.md)                          | Every external system behind a port with swappable adapters      |
+| [012](012-organization-manifest.md)                       | `org.yaml` as the top-level manifest with cascading overrides    |
+| [013](013-dood-over-dind.md)                              | Docker-outside-of-Docker over Docker-in-Docker                   |
+| [014](014-filesystem-messenger.md)                        | Filesystem inboxes for agent-to-agent messaging                  |
+| [015](015-lint-enforced-layering.md)                      | Layered imports enforced by depguard, not by convention          |
+
+Records 008, 009, 010 and 012 describe designed work that is not shipped; the
+chapter that owns each subject says where the code stands today.
+
+A new record starts from [`_template.md`](_template.md). An agent leaves the
+status `Proposed`; only the owner writes `Accepted`.

--- a/docs/decisions/_template.md
+++ b/docs/decisions/_template.md
@@ -1,0 +1,22 @@
+# ADR-NNN: Title
+
+**Status:** Proposed
+**Date:** YYYY-MM-DD
+
+An agent leaves the status `Proposed`; only the owner writes `Accepted`.
+
+A retroactive record carries one honest line here: written YYYY-MM-DD from
+the evidence it was reconstructed from. A record written at decision time
+carries nothing.
+
+## Context
+
+The situation that forced a decision — the forces, not the answer.
+
+## Decision
+
+What was decided, and the shape of the choice.
+
+## Consequences
+
+- What follows: costs accepted, freedoms gained, doors closed and opened.


### PR DESCRIPTION
The spwn product corpus in `jterrazz-os` (`home/spwn/wiki/`) carried the
engineering knowledge about this codebase: fourteen pages of design and
fourteen decision records. A commit here could falsify any of them without
touching the page that stated them, which is the test for where a fact
belongs. They move here.

**Decisions** — `docs/decisions/` now holds the fourteen records, numbers,
dates and statuses unchanged, with a README index. ADR-003 (security as
physics) stays in the product corpus: it decides about the product, not
about this codebase, and its number is left free here.

**Chapters** — four new ones for the text that had no home yet:

- `08-worlds.md` — how a world runs, the Backend port, what crosses the boundary.
- `09-physics.md` — constants, laws, elements; the world context an agent reads; the operating manual.
- `10-mind.md` — identity, skills, memory; Dream, Sleep, versioning a Mind.
- `11-observatory.md` — the web UI and the API behind it.

The rest merges into the chapter that already owned the subject: CLI
invariants into 03, manifest invariants into 04, the non-goals and the
planned surfaces into 05, what the gate is for and its invariants into 06.
Anything the repo already said was dropped rather than restated —
automations, the layer pyramid, the domain package map and the spec-first
flow were already written here.

`make lint` exit 0 · `make test` exit 0 · `make test-contracts` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVFxFrJLouipuR71DdZgkp