### PR TITLE
docs: the decisions number from 001 with no gap

### DIFF
--- a/docs/01-architecture.md
+++ b/docs/01-architecture.md
@@ -73,7 +73,7 @@ compile.Tree           →  world.Spawn        →  running container + synced a
 
 ## Container architecture: Docker-outside-of-Docker (DooD)
 
-spwn uses **DooD**, not DinD ([ADR-013](decisions/013-dood-over-dind.md)). The host's Docker daemon is shared via socket mount (`/var/run/docker.sock`); every container is a **sibling** on the same daemon — no nesting, no privilege escalation, no performance overhead.
+spwn uses **DooD**, not DinD ([ADR-012](decisions/012-dood-over-dind.md)). The host's Docker daemon is shared via socket mount (`/var/run/docker.sock`); every container is a **sibling** on the same daemon — no nesting, no privilege escalation, no performance overhead.
 
 ```
 Host machine
@@ -99,7 +99,7 @@ The [gate](08-gate.md) is a separate long-running host container that owns cooki
 - **Labels are truth.** World state comes from Docker labels, not on-disk state.
 - **Compile is deterministic.** Same input → same output, covered by golden tests.
 - **Layers flow downward.** Enforced by depguard; no upward imports.
-- **External systems sit behind ports.** Every dependency on the outside world is a Go interface defined in the domain that uses it, with the adapter injected at startup — no domain package names a concrete backend ([ADR-011](decisions/011-ports-and-adapters.md)).
+- **External systems sit behind ports.** Every dependency on the outside world is a Go interface defined in the domain that uses it, with the adapter injected at startup — no domain package names a concrete backend ([ADR-010](decisions/010-ports-and-adapters.md)).
 
 ## What the architecture does not do
 
@@ -116,7 +116,7 @@ The boundaries are as load-bearing as the layers:
 
 Thin SDKs are designed, not shipped: language wrappers (TypeScript first, then Python) over the same domain APIs the CLI consumes, so code can act as an operator — spawn a world, assign a task, collect the result — without shelling out. Today the shipped operator surfaces are the CLI and the web UI.
 
-The runtime stack has further designed-but-unshipped layers, each with its own record: a runtime normalization layer inside worlds ([ADR-008](decisions/008-rivet-runtime-layer.md)), multi-provider and subscription auth behind it ([ADR-010](decisions/010-pi-mono-multi-provider.md)), and the Architect's messaging channels ([ADR-009](decisions/009-zeroclaw-as-claw.md), [ADR-012](decisions/012-organization-manifest.md)).
+The runtime stack has further designed-but-unshipped layers, each with its own record: a runtime normalization layer inside worlds ([ADR-007](decisions/007-rivet-runtime-layer.md)), multi-provider and subscription auth behind it ([ADR-009](decisions/009-pi-mono-multi-provider.md)), and the Architect's messaging channels ([ADR-008](decisions/008-zeroclaw-as-claw.md), [ADR-011](decisions/011-organization-manifest.md)).
 
 ## Related
 

--- a/docs/02-developing.md
+++ b/docs/02-developing.md
@@ -96,7 +96,7 @@ Four things land in the same commit as the change that makes them true:
 
 A decision this repository alone took is written to [`decisions/`](decisions/) as `NNN-kebab.md`, cut from [`decisions/_template.md`](decisions/_template.md). The status is `Proposed` until the owner writes `Accepted` — an agent never accepts its own record.
 
-Numbers are historical and never reused, which is why 003 is absent: *security as physics* is a decision about the product rather than about this codebase, and it lives in spwn's product knowledge outside this repository. A decision spanning two repositories is recorded in the corpus that spans them, and linked from here.
+The sequence runs `001` to the latest with no gap: a record that moves or is removed shifts the ones after it down rather than leaving a hole. The record that once held 003 — *security as physics*, a decision about the product rather than about this codebase — was withdrawn to spwn's product knowledge outside this repository, and the sequence closed the gap on 2026-09-09.
 
 ## Related
 

--- a/docs/08-gate.md
+++ b/docs/08-gate.md
@@ -93,4 +93,4 @@ Undecided — whether two worlds should be able to reach each other. No direct c
 - [Primitives](07-primitives.md) — the `gate:` block on a `tool.yaml`.
 - [Physics](10-physics.md) — why a bridged capability is modelled as an element.
 - [Architecture](01-architecture.md) — where the gate sits relative to worlds.
-- [ADR-001](decisions/001-gate-over-socket.md) · [ADR-006](decisions/006-acp-inside-container.md) · [ADR-007](decisions/007-rust-container-gate.md) — the transport abstraction and the two-sided design that preceded the shipped host broker.
+- [ADR-001](decisions/001-gate-over-socket.md) · [ADR-005](decisions/005-acp-inside-container.md) · [ADR-006](decisions/006-rust-container-gate.md) — the transport abstraction and the two-sided design that preceded the shipped host broker.

--- a/docs/09-worlds.md
+++ b/docs/09-worlds.md
@@ -11,7 +11,7 @@ A world is a Docker container started from the project image, and everything an 
 
 ## The Backend port
 
-The machinery programs against an interface — provision, exec, mount, destroy, ensure-image — never against Docker itself ([`packages/container`](../packages/container) is the adapter, and [ADR-011](decisions/011-ports-and-adapters.md) the rule). Nothing above the port names Docker, which keeps the door open for stronger isolation backends without changing agent-facing behaviour.
+The machinery programs against an interface — provision, exec, mount, destroy, ensure-image — never against Docker itself ([`packages/container`](../packages/container) is the adapter, and [ADR-010](decisions/010-ports-and-adapters.md) the rule). Nothing above the port names Docker, which keeps the door open for stronger isolation backends without changing agent-facing behaviour.
 
 Docker is the default and, today, the only adapter. Designed, not shipped: edge deployment — ephemeral agents on lightweight infrastructure — as a second adapter behind the same port.
 

--- a/docs/11-mind.md
+++ b/docs/11-mind.md
@@ -48,7 +48,7 @@ The Soul is the identity layer: purpose, values, bonds. The Mind is everything t
 | During Fork  | Shared across all forks          | Each fork gets its own copy              |
 | During Merge | No conflict possible             | Needs conflict resolution                |
 
-Because Claude Code is the runtime spawned inside the world ([ADR-004](decisions/004-claude-code-as-runtime.md)), these files are read natively as markdown: `SOUL.md` and `AGENTS.md` shape identity the way `.claude/agents/` does, `playbooks/` the way `.claude/skills/` does. There is no custom loader.
+Because Claude Code is the runtime spawned inside the world ([ADR-003](decisions/003-claude-code-as-runtime.md)), these files are read natively as markdown: `SOUL.md` and `AGENTS.md` shape identity the way `.claude/agents/` does, `playbooks/` the way `.claude/skills/` does. There is no custom loader.
 
 ## Lifecycle and mount
 

--- a/docs/12-observatory.md
+++ b/docs/12-observatory.md
@@ -15,7 +15,7 @@ A Next.js application ([`apps/web`](../apps/web)) backed by a Go API server ([`a
 
 ## Designed, not shipped
 
-The long-term target is an isometric, real-time visualisation of worlds and the agents working inside them, fed by runtime event streaming ([ADR-008](decisions/008-rivet-runtime-layer.md)). Today the dashboard is the flat web UI described above.
+The long-term target is an isometric, real-time visualisation of worlds and the agents working inside them, fed by runtime event streaming ([ADR-007](decisions/007-rivet-runtime-layer.md)). Today the dashboard is the flat web UI described above.
 
 ## Related
 

--- a/docs/decisions/003-claude-code-as-runtime.md
+++ b/docs/decisions/003-claude-code-as-runtime.md
@@ -1,4 +1,4 @@
-# ADR-004: Claude Code CLI as Agent Runtime
+# ADR-003: Claude Code CLI as Agent Runtime
 
 **Date:** 2026-02-28
 **Status:** Accepted

--- a/docs/decisions/004-go-core.md
+++ b/docs/decisions/004-go-core.md
@@ -1,11 +1,11 @@
-# ADR-005: Go for Core Library
+# ADR-004: Go for Core Library
 
 **Date:** 2026-02-28
 **Status:** Accepted
 
 ## Context
 
-Spwn needs a core implementation language for the business logic: lifecycle management, Mind management, physics generation, element bridging, and backend orchestration. The original design used TypeScript, then briefly Rust. With the pivot to Claude Code as the agent runtime (ADR-004), the primary workload is Docker orchestration + CLI — not performance-critical computation.
+Spwn needs a core implementation language for the business logic: lifecycle management, Mind management, physics generation, element bridging, and backend orchestration. The original design used TypeScript, then briefly Rust. With the pivot to Claude Code as the agent runtime (ADR-003), the primary workload is Docker orchestration + CLI — not performance-critical computation.
 
 This is infrastructure glue. The right language for Docker orchestration is the one the Docker ecosystem is built in.
 

--- a/docs/decisions/005-acp-inside-container.md
+++ b/docs/decisions/005-acp-inside-container.md
@@ -1,4 +1,4 @@
-# ADR-006: Agent Client Protocol Inside the Container
+# ADR-005: Agent Client Protocol Inside the Container
 
 **Date:** 2026-03-01
 **Status:** Accepted

--- a/docs/decisions/006-rust-container-gate.md
+++ b/docs/decisions/006-rust-container-gate.md
@@ -1,4 +1,4 @@
-# ADR-007: Rust for the Container-Side Gate
+# ADR-006: Rust for the Container-Side Gate
 
 **Date:** 2026-03-01
 **Status:** Accepted

--- a/docs/decisions/007-rivet-runtime-layer.md
+++ b/docs/decisions/007-rivet-runtime-layer.md
@@ -1,4 +1,4 @@
-# ADR-008: Rivet Sandbox Agent SDK as the Runtime Normalization Layer
+# ADR-007: Rivet Sandbox Agent SDK as the Runtime Normalization Layer
 
 **Status:** Accepted
 **Date:** 2026-03-29

--- a/docs/decisions/008-zeroclaw-as-claw.md
+++ b/docs/decisions/008-zeroclaw-as-claw.md
@@ -1,4 +1,4 @@
-# ADR-009: ZeroClaw as the Architect Daemon
+# ADR-008: ZeroClaw as the Architect Daemon
 
 **Status:** Accepted
 **Date:** 2026-03-29

--- a/docs/decisions/009-pi-mono-multi-provider.md
+++ b/docs/decisions/009-pi-mono-multi-provider.md
@@ -1,4 +1,4 @@
-# ADR-010: Pi-mono as the Primary Multi-Provider Runtime
+# ADR-009: Pi-mono as the Primary Multi-Provider Runtime
 
 **Status:** Accepted
 **Date:** 2026-03-29

--- a/docs/decisions/010-ports-and-adapters.md
+++ b/docs/decisions/010-ports-and-adapters.md
@@ -1,4 +1,4 @@
-# ADR-011: Ports & Adapters (Trait-Driven Architecture)
+# ADR-010: Ports & Adapters (Trait-Driven Architecture)
 
 **Status:** Accepted
 **Date:** 2026-03-29

--- a/docs/decisions/011-organization-manifest.md
+++ b/docs/decisions/011-organization-manifest.md
@@ -1,4 +1,4 @@
-# ADR-012: Universe Manifest (`org.yaml`)
+# ADR-011: Universe Manifest (`org.yaml`)
 
 **Status:** Accepted
 **Date:** 2026-03-29

--- a/docs/decisions/012-dood-over-dind.md
+++ b/docs/decisions/012-dood-over-dind.md
@@ -1,4 +1,4 @@
-# ADR-013: Docker-out-of-Docker (DooD) over Docker-in-Docker (DinD)
+# ADR-012: Docker-out-of-Docker (DooD) over Docker-in-Docker (DinD)
 
 **Status:** Accepted
 **Date:** 2026-04-01

--- a/docs/decisions/013-filesystem-messenger.md
+++ b/docs/decisions/013-filesystem-messenger.md
@@ -1,4 +1,4 @@
-# ADR-014: Filesystem-Based Agent Messaging
+# ADR-013: Filesystem-Based Agent Messaging
 
 **Status:** Accepted
 **Date:** 2026-03-31

--- a/docs/decisions/014-lint-enforced-layering.md
+++ b/docs/decisions/014-lint-enforced-layering.md
@@ -1,4 +1,4 @@
-# ADR-015: Lint-Enforced Layered Imports
+# ADR-014: Lint-Enforced Layered Imports
 
 **Date:** 2026-04-16
 **Status:** Accepted

--- a/docs/decisions/015-codex-as-a-first-class-runtime.md
+++ b/docs/decisions/015-codex-as-a-first-class-runtime.md
@@ -1,4 +1,4 @@
-# ADR-016: codex as a first-class runtime
+# ADR-015: codex as a first-class runtime
 
 **Status:** Proposed
 **Date:** 2026-09-09
@@ -46,7 +46,7 @@ and the `Spawner` interface grows the two pieces of dialect the CLI had
 inlined, `OneShotFlags` (the flags that tell a CLI to print and exit) and
 `ParseOneShotResult` (the text and session id read back out).
 
-This is [ADR-011](011-ports-and-adapters.md) applied to a port that had one
+This is [ADR-010](010-ports-and-adapters.md) applied to a port that had one
 implementation and had therefore stopped being one. A second runtime is the
 only thing that can prove a runtime port is a port, which is why the promotion
 is a decision and not a feature: it fixes a boundary, and adding a third


### PR DESCRIPTION
## Summary
- The owner's decision (2026-09-09, landing as `docs-decision-sequence` in `@jterrazz/typescript` 9.3.0) requires `decisions/` to number `001..N` with no gap; `docs/decisions/` ran 001, 002, 004..016 with 003 absent.
- Closes the gap: `004..016` renamed `git mv` down to `003..015` (slugs kept), each `# ADR-NNN:` heading and every `[ADR-NNN](NNN-…)` link or plain-text reference in `docs/` repointed.
- The paragraph in `docs/02-developing.md` explaining why ADR-003 was absent is replaced with one line: the record that held it was withdrawn, and the sequence closed the gap on 2026-09-09.
- One historical quote in `docs/decisions/013-filesystem-messenger.md` (a verbatim commit message reading `"docs: ADR-012 filesystem-based messenger"`) is left untouched — it records what that commit literally said, not a live cross-reference, and rewriting it would misrepresent history.

## Test plan
- [x] `ls docs/decisions | grep -E '^[0-9]{3}-' | sed 's/-.*//'` prints `001`..`015` contiguous
- [x] `git grep -nE "decisions/(004-claude-code-as-runtime|005-go-core|006-acp-inside-container|007-rust-container-gate|008-rivet-runtime-layer|009-zeroclaw-as-claw|010-pi-mono-multi-provider|011-ports-and-adapters|012-organization-manifest|013-dood-over-dind|014-filesystem-messenger|015-lint-enforced-layering|016-codex-as-a-first-class-runtime)"` — empty (no stale old number/slug pairing remains anywhere in the tree)
- [x] `make lint` exit 0

Merging this PR does not deploy — spwn releases on tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvTjLJ8q84pEmsd87A4E2K